### PR TITLE
Clean up PHP8.0 and HTML5 syntax for admin templates; fix CSS width issues

### DIFF
--- a/css/peq.css
+++ b/css/peq.css
@@ -130,7 +130,7 @@ table {
 }
 
 #searchbar select {
-  width: 180px;
+  width: 160px;
   font-size: 12px;
 }
 
@@ -182,10 +182,11 @@ table {
 }
 
 .edit_form_header {
-  padding: 0 5px 3px 5px;
-  background-color: black;
+  padding: 0 10px 3px 10px;
+  background-color: #000;
   color: #FFF;
-  font-size: 12px
+  font-size: 12px;
+  min-width: 200px;
 }
 
 .edit_form_content {
@@ -193,6 +194,7 @@ table {
   color: #000;
   font-size: 12px;
   background-color: #CCC;
+  min-width: 200px;
 }
 
 .edit_form_content_small {

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 
-$current_revision = "26 December 2023";
+$current_revision = "29 December 2023";
 
 require_once("config.php");
 require_once("lib/logging.php");

--- a/templates/admin/admin.add.tmpl.php
+++ b/templates/admin/admin.add.tmpl.php
@@ -1,29 +1,29 @@
-      <center>
-        <br><br><br>
-        <h1>User Management</h1>
-        <br><br>
-      </center>
+<div class="center">
+    <br><br><br>
+    <h1>User Management</h1>
+    <br><br>
+</div>
 
-      <form method="post" action="index.php?admin&action=5">
-        <div class="edit_form" style="width:200px;">
-          <div class="edit_form_header">
+<form method="post" action="index.php?admin&action=5">
+    <div class="edit_form" style="width:200px;">
+        <div class="edit_form_header">
             User List
-          </div>
-          <div class="edit_form_content">
-            <strong>Username</strong><br>
-            <input class="indented" type="text" name="login" value=""><br><br>
-            
-            <strong>Password</strong><br>
-            <input class="indented" type="text" name="password" value=""><br><br>
-
-            <strong>Status</strong><br>
-            <select class="indented" name="administrator">
-              <option value="0">User</option>
-              <option value="1">Administrator</option>
-            </select><br><br><br>
-            <center>
-              <input type="submit" value="Add User">
-            </center>
-          </div>
         </div>
-      </form>
+        <div class="edit_form_content">
+            <label for="login"><strong>Username</strong></label><br>
+            <input class="indented" type="text" id="login" name="login" value=""><br><br>
+
+            <label for="password"><strong>Password</strong><br></label>
+            <input class="indented" type="text" id="password" name="password" value=""><br><br>
+
+            <label for="administrator"><strong>Status</strong><br></label>
+            <select class="indented" id="administrator" name="administrator">
+                <option value="0">User</option>
+                <option value="1">Administrator</option>
+            </select><br><br><br>
+            <div class="center">
+                <input type="submit" value="Add User">
+            </div>
+        </div>
+    </div>
+</form>

--- a/templates/admin/admin.edit.tmpl.php
+++ b/templates/admin/admin.edit.tmpl.php
@@ -1,32 +1,32 @@
-<?extract($user);?>
-      <center>
-        <br><br><br>
-        <h1>User Management</h1>
-        <br><br>
-      </center>
+<?php if(isset($user)) { extract($user); }?>
+<div class="center">
+    <br><br><br>
+    <h1>User Management</h1>
+    <br><br>
+</div>
 
-      <form method="post" action="index.php?admin&action=2">
-        <div class="edit_form" style="width:200px;">
-          <div class="edit_form_header">
+<form method="post" action="index.php?admin&action=2">
+    <div class="edit_form" style="width:200px;">
+        <div class="edit_form_header">
             User List
-          </div>
-          <div class="edit_form_content">
-            <strong>Username</strong><br>
-            <input class="indented" type="text" name="login" value="<?=$login?>"><br><br>
-            
-            <strong>Change Password</strong><br>
-            <input class="indented" type="text" name="password" value=""><br>
+        </div>
+        <div class="edit_form_content">
+            <label for="login"><strong>Username</strong><br></label>
+            <input class="indented" type="text" id="login" name="login" value="<?= $login ?? "" ?>"><br><br>
+
+            <label for="password"><strong>Change Password</strong><br></label>
+            <input class="indented" type="text" id="password" name="password" value=""><br>
             (leave blank for no change)<br><br>
 
-            <strong>Status</strong><br>
-            <select class="indented" name="administrator">
-              <option value="0"<?echo ($administrator == 0) ? " selected" : "";?>>User</option>
-              <option value="1"<?echo ($administrator == 1) ? " selected" : "";?>>Administrator</option>
+            <label for="administrator"><strong>Status</strong><br></label>
+            <select class="indented" id="administrator" name="administrator">
+                <option value="0"<?php echo (($administrator ?? 0) == 0) ? " selected" : ""; ?>>User</option>
+                <option value="1"<?php echo (($administrator ?? 0) == 1) ? " selected" : ""; ?>>Administrator</option>
             </select><br><br><br>
-            <center>
-              <input type="hidden" name="id" value="<?=$id?>">
-              <input type="submit" value="Update User">
-            </center>
-          </div>
+            <div class="center">
+                <input type="hidden" name="id" value="<?= $id ?? 0 ?>">
+                <input type="submit" value="Update User">
+            </div>
         </div>
-      </form>
+    </div>
+</form>

--- a/templates/admin/admin.tmpl.php
+++ b/templates/admin/admin.tmpl.php
@@ -1,4 +1,4 @@
-  <center>
+  <div class="center">
     <br /><br /><br />
     <h1>User Management</h1>
     <br /><br />
@@ -6,29 +6,29 @@
       <div class="table_header">
         User List
         <div style="float: right">
-          <a href="index.php?admin&action=4"><img src="images/add.gif" border="0" title="Add User" /></a>
+          <a href="index.php?admin&action=4"><img src="images/add.gif" style="border: 0;" alt="Yellow Plus Icon" title="Add User" /></a>
         </div>
       </div>
       <div class="table_content">
-        <table width="100%">
+        <table style="width: 100%;">
           <tr>
-            <th align="left">Username</th>
-            <th align="center">Status</th>
+            <th style="text-align: left;">Username</th>
+            <th style="text-align: center;">Status</th>
             <th>&nbsp;</th>
           </tr>
-<?foreach($users as $user): extract($user);?>
+            <?php global $users; foreach($users as $user): extract($user);?>
           <tr>
-            <td align="left"><?=$login?></td>
-            <td align="center"><?echo ($administrator == 1) ? "Admin" : "User";?></td>
-            <td align="right">
-              <a href="index.php?admin&id=<?=$id?>&action=1"><img src="images/edit2.gif" border="0" title="Edit User" /></a>&nbsp;
+            <td style="text-align: left"><?=$login?></td>
+            <td style="text-align: center"><?php echo ($administrator == 1) ? "Admin" : "User";?></td>
+            <td style="text-align: right">
+              <a href="index.php?admin&id=<?=$id?>&action=1"><img src="images/edit2.gif" style="border: 0;" alt="Edit Icon" title="Edit User" /></a>&nbsp;
               <a href="index.php?admin&id=<?=$id?>&action=3" onClick="return confirm('Really delete this user?');">
-                <img src="images/remove.gif" border="0" title="Delete User" />
+                <img src="images/remove.gif" style="border: 0;" alt="Red X Icon" title="Delete User" />
               </a>
             </td>
           </tr>
-<?endforeach;?>
+            <?php endforeach;?>
         </table>
       </div>
     </div>
-  </center>
+  </div>


### PR DESCRIPTION
In addition to fixing errors and warnings for the admin templates, also fixed some CSS issues with width.

**CSS edit_form width changes this:**
<img width="633" alt="Screenshot 2023-12-29 at 12 40 32 AM" src="https://github.com/EQMacEmu/takpphpeditor/assets/8131324/9d719c43-b4bf-4ce8-a9fb-5db4a56392d8">

**to this:**
<img width="625" alt="Screenshot 2023-12-29 at 12 41 24 AM" src="https://github.com/EQMacEmu/takpphpeditor/assets/8131324/b9cadca4-fb33-4691-8d84-91ce7a75c03e">

**Loot header changed from this:**
<img width="869" alt="Screenshot 2023-12-29 at 12 43 13 AM" src="https://github.com/EQMacEmu/takpphpeditor/assets/8131324/9e9a71c3-d85f-4b02-8b53-0dafd7ba3ff7">

**to this:**
<img width="849" alt="Screenshot 2023-12-29 at 12 42 48 AM" src="https://github.com/EQMacEmu/takpphpeditor/assets/8131324/6d493353-e2e3-4f67-bf93-8a81c1c09a72">
