### PR TITLE
Updates to HTML5/PHP8.0 syntax for misc folder; fixes to (Door, Trap,…

### DIFF
--- a/lib/misc.php
+++ b/lib/misc.php
@@ -1,1071 +1,1093 @@
 <?php
 
 $traptype = array(
-  0   => "Casting",
-  1   => "Alarm",
-  2   => "NPC S. Area (Mystics)",
-  3   => "NPC L. Area (Bandits)",
-  4   => "Damage"
+    0 => "Casting",
+    1 => "Alarm",
+    2 => "NPC S. Area (Mystics)",
+    3 => "NPC L. Area (Bandits)",
+    4 => "Damage"
 );
 
 $alarmtype = array(
-  0   => "All aggro",
-  1   => "KOS aggro"
+    0 => "All aggro",
+    1 => "KOS aggro"
 );
 
 switch ($action) {
-  case 0:
-    if ($z) {
-      $body = new Template("templates/misc/misc.default.tmpl.php");
-      $body->set('currzone', $z);
-      $body->set('currzoneid', $zoneid);
-    }
-    break;
-  case 1: // View fishing
-    $body = new Template("templates/misc/fishing.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $fishing = get_fishing();
-    if ($fishing) {
-      foreach ($fishing as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-  case 2: // Edit fishing
-    check_authorization();
-    $javascript = new Template("templates/iframes/js.tmpl.php");
-    $body = new Template("templates/misc/fishing.edit.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $fishing = fishing_info();
-    if ($fishing) {
-      foreach ($fishing as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-  case 3: // Update fishing
-    check_authorization();
-    update_fishing();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=1");
-    exit;
-  case 4: // Delete fishing
-    check_authorization();
-    delete_fishing();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=1");
-    exit;
-  case 5: // Get fishing ID
-    check_authorization();
-    $javascript = new Template("templates/iframes/js.tmpl.php");
-    $body = new Template("templates/misc/fishing.add.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $body->set('zid', getZoneID($z));
-    $body->set('suggestfsid', suggest_fishing_id());
-    break;
-  case 6: // Add fishing
-    check_authorization();
-    add_fishing();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=1");
-    exit;
-  case 7: // View forage
-    $body = new Template("templates/misc/forage.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $forage = get_forage();
-    if ($forage) {
-      foreach ($forage as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-   case 8: // Edit forage
-    check_authorization();
-    $javascript = new Template("templates/iframes/js.tmpl.php");
-    $body = new Template("templates/misc/forage.edit.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $forage = forage_info();
-    if ($forage) {
-      foreach ($forage as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-   case 9: // Update forage
-    check_authorization();
-    update_forage();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=7");
-    exit;
-   case 10: // Delete forage
-    check_authorization();
-    delete_forage();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=7");
-    exit;
-   case 11: // Get forage ID
-    check_authorization();
-    $javascript = new Template("templates/iframes/js.tmpl.php");
-    $body = new Template("templates/misc/forage.add.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $body->set('zid', getZoneID($z));
-    $body->set('suggestfgid', suggest_forage_id());
-    break;
-   case 12: // Add forage
-    check_authorization();
-    add_forage();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=7");
-    exit;
-   case 13: // View ground spawns
-    check_authorization();
-    $body = new Template("templates/misc/groundspawn.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $gspawn = get_gspawn();
-    if ($gspawn) {
-      foreach ($gspawn as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-   case 14: // Edit ground spawns
-    check_authorization();
-    $javascript = new Template("templates/iframes/js.tmpl.php");
-    $body = new Template("templates/misc/groundspawn.edit.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $gspawn = gspawn_info();
-    if ($gspawn) {
-      foreach ($gspawn as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-   case 15: // Update ground spawns
-    check_authorization();
-    update_gspawn();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=13");
-    exit;
-   case 16: // Delete ground spawns
-    check_authorization();
-    delete_gspawn();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=13");
-    exit;
-   case 17: // Get ground spawn ID
-    check_authorization();
-    $javascript = new Template("templates/iframes/js.tmpl.php");
-    $body = new Template("templates/misc/groundspawn.add.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $body->set('zid', getZoneID($z));
-    $body->set('suggestgsid', suggest_gspawn_id());
-    break;
-   case 18: // Add ground spawn
-    check_authorization();
-    add_gspawn();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=13");
-    exit;
-   case 19: // View traps
-    check_authorization();
-    $body = new Template("templates/misc/traps.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $body->set("traptype", $traptype);
-    $body->set("alarmtype", $alarmtype);
-    $traps = get_traps();
-    if ($traps) {
-      foreach ($traps as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-   case 20: // Edit traps
-    check_authorization();
-    $body = new Template("templates/misc/traps.edit.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $body->set("traptype", $traptype);
-    $body->set('yesno', $yesno);
-    $traps = traps_info();
-    if ($traps) {
-      foreach ($traps as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-   case 21: // Update traps
-    check_authorization();
-    update_traps();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=19");
-    exit;
-   case 22: // Delete traps
-    check_authorization();
-    delete_traps();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=19");
-    exit;
-   case 23: // Get traps ID
-    check_authorization();
-    $body = new Template("templates/misc/traps.add.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $body->set("traptype", $traptype);
-    $body->set("alarmtype", $alarmtype);
-    $body->set('yesno', $yesno);
-    $body->set('suggesttid', suggest_traps_id());
-    break;
-   case 24: // Add traps
-    check_authorization();
-    add_traps();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=19");
-    exit;
-   case 25:  // Search functions
-    $body = new Template("templates/misc/misc.searchresults.tmpl.php");
-    if (isset($_GET['gspawnid']) && $_GET['gspawnid'] != "GroundSpawn"){
-       $gspawn = search_gspawn_by_id();
-    }
-    if (isset($_GET['forageid']) && $_GET['forageid'] != "Forage"){
-       $forage = search_forage_by_id();
-    }
-    if (isset($_GET['fishid']) && $_GET['fishid'] != "Fishing"){
-       $fishing = search_fishing_by_id();
-    }
-    $body->set("fishing", $fishing);
-    $body->set("forage", $forage);
-    $body->set("gspawn", $gspawn);
-    break;
-   case 26: // View fishing
-    $body = new Template("templates/misc/fishing.view.tmpl.php");
-    $fishing = fishing_info();
-    if ($fishing) {
-      foreach ($fishing as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-   case 27: // View forage
-    $body = new Template("templates/misc/forage.view.tmpl.php");
-    $forage = forage_info();
-    if ($forage) {
-      foreach ($forage as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-   case 28: // View ground spawns
-    check_authorization();
-    $body = new Template("templates/misc/groundspawn.view.tmpl.php");
-    $gspawn = gspawn_info();
-    if ($gspawn) {
-      foreach ($gspawn as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-   case 29: // View horses
-    $body = new Template("templates/misc/horses.tmpl.php");
-    $horses = get_horses();
-    $body->set("races", $races);
-    $body->set("genders", $genders);
-    if ($horses) {
-      foreach ($horses as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-   case 30: // Edit horses
-    check_authorization();
-    $body = new Template("templates/misc/horses.edit.tmpl.php");
-    $body->set("races", $races);
-    $body->set("genders", $genders);
-    $horses = horses_info();
-    if ($horses) {
-      foreach ($horses as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-   case 31: // Update horses
-    check_authorization();
-    update_horses();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=29");
-    exit;
-   case 32: // Delete horses
-    check_authorization();
-    delete_horses();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=29");
-    exit;
-   case 33: // Add horses
-    check_authorization();
-    $body = new Template("templates/misc/horses.add.tmpl.php");
-    $body->set("races", $races);
-    $body->set("genders", $genders);
-    break;
-   case 34: // Add horses
-    check_authorization();
-    add_horses();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=29");
-    exit;
-   case 35: // View doors
-    $body = new Template("templates/misc/doors.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $doors = get_doors(1);
-    if ($doors) {
-      foreach ($doors as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-  case 36: // Edit doors
-    check_authorization();
-    $body = new Template("templates/misc/doors.edit.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $body->set('yesno', $yesno);
-    $doors = doors_info();
-    if ($doors) {
-      foreach ($doors as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-  case 37: // Update doors
-    check_authorization();
-    update_doors();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=35");
-    exit;
-  case 38: // Delete doors
-    check_authorization();
-    delete_doors();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=35");
-    exit;
-  case 39: // Get doors ID
-    check_authorization();
-    $body = new Template("templates/misc/doors.add.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $body->set('zid', getZoneID($z));
-    $body->set('suggestdrid', suggest_door_id());
-    $body->set('suggestdoorid', suggest_doorid());
-    $body->set('yesno', $yesno);
-    break;
-  case 40: // Add doors
-    check_authorization();
-    add_doors();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=35");
-    exit;
-  case 41: // View objects
-    $body = new Template("templates/misc/objects.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $body->set("world_containers", $world_containers);
-    $objects = get_objects();
-    if ($objects) {
-      foreach ($objects as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-  case 42: // Edit objects
-    check_authorization();
-    $body = new Template("templates/misc/objects.edit.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $body->set("world_containers", $world_containers);
-    $objects = objects_info();
-    if ($objects) {
-      foreach ($objects as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
-  case 43: // Update objects
-    check_authorization();
-    update_objects();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=41");
-    exit;
-  case 44: // Delete objects
-    check_authorization();
-    delete_objects();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=41");
-    exit;
-  case 45: // Get objects ID
-    check_authorization();
-    $body = new Template("templates/misc/objects.add.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $body->set('zid', getZoneID($z));
-    $body->set("world_containers", $world_containers);
-    $body->set('suggestobjid', suggest_object_id());
-    break;
-  case 46: // Add objects
-    check_authorization();
-    add_objects();
-    header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=41");
-    exit;
-  case 47: // View doors
-    $body = new Template("templates/misc/doors.objects.tmpl.php");
-    $body->set('currzone', $z);
-    $body->set('currzoneid', $zoneid);
-    $doors = get_doors(0);
-    if ($doors) {
-      foreach ($doors as $key=>$value) {
-        $body->set($key, $value);
-      }
-    }
-    break;
+    case 0:
+        if ($z) {
+            $body = new Template("templates/misc/misc.default.tmpl.php");
+            $body->set('currzone', $z);
+            $body->set('currzoneid', $zoneid);
+        }
+        break;
+    case 1: // View fishing
+        $body = new Template("templates/misc/fishing.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $fishing = get_fishing();
+        if ($fishing) {
+            foreach ($fishing as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 2: // Edit fishing
+        check_authorization();
+        $javascript = new Template("templates/iframes/js.tmpl.php");
+        $body = new Template("templates/misc/fishing.edit.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $fishing = fishing_info();
+        if ($fishing) {
+            foreach ($fishing as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 3: // Update fishing
+        check_authorization();
+        update_fishing();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=1");
+        exit;
+    case 4: // Delete fishing
+        check_authorization();
+        delete_fishing();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=1");
+        exit;
+    case 5: // Get fishing ID
+        check_authorization();
+        $javascript = new Template("templates/iframes/js.tmpl.php");
+        $body = new Template("templates/misc/fishing.add.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $body->set('zid', getZoneID($z));
+        $body->set('suggestfsid', suggest_fishing_id());
+        break;
+    case 6: // Add fishing
+        check_authorization();
+        add_fishing();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=1");
+        exit;
+    case 7: // View forage
+        $body = new Template("templates/misc/forage.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $forage = get_forage();
+        if ($forage) {
+            foreach ($forage as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 8: // Edit forage
+        check_authorization();
+        $javascript = new Template("templates/iframes/js.tmpl.php");
+        $body = new Template("templates/misc/forage.edit.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $forage = forage_info();
+        if ($forage) {
+            foreach ($forage as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 9: // Update forage
+        check_authorization();
+        update_forage();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=7");
+        exit;
+    case 10: // Delete forage
+        check_authorization();
+        delete_forage();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=7");
+        exit;
+    case 11: // Get forage ID
+        check_authorization();
+        $javascript = new Template("templates/iframes/js.tmpl.php");
+        $body = new Template("templates/misc/forage.add.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $body->set('zid', getZoneID($z));
+        $body->set('suggestfgid', suggest_forage_id());
+        break;
+    case 12: // Add forage
+        check_authorization();
+        add_forage();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=7");
+        exit;
+    case 13: // View ground spawns
+        check_authorization();
+        $body = new Template("templates/misc/groundspawn.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $gspawn = get_gspawn();
+        if ($gspawn) {
+            foreach ($gspawn as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 14: // Edit ground spawns
+        check_authorization();
+        $javascript = new Template("templates/iframes/js.tmpl.php");
+        $body = new Template("templates/misc/groundspawn.edit.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $gspawn = gspawn_info();
+        if ($gspawn) {
+            foreach ($gspawn as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 15: // Update ground spawns
+        check_authorization();
+        update_gspawn();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=13");
+        exit;
+    case 16: // Delete ground spawns
+        check_authorization();
+        delete_gspawn();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=13");
+        exit;
+    case 17: // Get ground spawn ID
+        check_authorization();
+        $javascript = new Template("templates/iframes/js.tmpl.php");
+        $body = new Template("templates/misc/groundspawn.add.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $body->set('zid', getZoneID($z));
+        $body->set('suggestgsid', suggest_gspawn_id());
+        break;
+    case 18: // Add ground spawn
+        check_authorization();
+        add_gspawn();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=13");
+        exit;
+    case 19: // View traps
+        check_authorization();
+        $body = new Template("templates/misc/traps.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $body->set("traptype", $traptype);
+        $body->set("alarmtype", $alarmtype);
+        $traps = get_traps();
+        if ($traps) {
+            foreach ($traps as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 20: // Edit traps
+        check_authorization();
+        $body = new Template("templates/misc/traps.edit.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $body->set("traptype", $traptype);
+        $body->set('yesno', $yesno);
+        $traps = traps_info();
+        if ($traps) {
+            foreach ($traps as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 21: // Update traps
+        check_authorization();
+        update_traps();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=19");
+        exit;
+    case 22: // Delete traps
+        check_authorization();
+        delete_traps();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=19");
+        exit;
+    case 23: // Get traps ID
+        check_authorization();
+        $body = new Template("templates/misc/traps.add.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $body->set("traptype", $traptype);
+        $body->set("alarmtype", $alarmtype);
+        $body->set('yesno', $yesno);
+        $body->set('suggesttid', suggest_traps_id());
+        break;
+    case 24: // Add traps
+        check_authorization();
+        add_traps();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=19");
+        exit;
+    case 25:  // Search functions
+        $body = new Template("templates/misc/misc.searchresults.tmpl.php");
+        if (isset($_GET['gspawnid']) && $_GET['gspawnid'] != "GroundSpawn") {
+            $gspawn = search_gspawn_by_id();
+        }
+        if (isset($_GET['forageid']) && $_GET['forageid'] != "Forage") {
+            $forage = search_forage_by_id();
+        }
+        if (isset($_GET['fishid']) && $_GET['fishid'] != "Fishing") {
+            $fishing = search_fishing_by_id();
+        }
+        $body->set("fishing", $fishing);
+        $body->set("forage", $forage);
+        $body->set("gspawn", $gspawn);
+        break;
+    case 26: // View fishing
+        $body = new Template("templates/misc/fishing.view.tmpl.php");
+        $fishing = fishing_info();
+        if ($fishing) {
+            foreach ($fishing as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 27: // View forage
+        $body = new Template("templates/misc/forage.view.tmpl.php");
+        $forage = forage_info();
+        if ($forage) {
+            foreach ($forage as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 28: // View ground spawns
+        check_authorization();
+        $body = new Template("templates/misc/groundspawn.view.tmpl.php");
+        $gspawn = gspawn_info();
+        if ($gspawn) {
+            foreach ($gspawn as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 29: // View horses
+        $body = new Template("templates/misc/horses.tmpl.php");
+        $horses = get_horses();
+        $body->set("races", $races);
+        $body->set("genders", $genders);
+        if ($horses) {
+            foreach ($horses as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 30: // Edit horses
+        check_authorization();
+        $body = new Template("templates/misc/horses.edit.tmpl.php");
+        $body->set("races", $races);
+        $body->set("genders", $genders);
+        $horses = horses_info();
+        if ($horses) {
+            foreach ($horses as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 31: // Update horses
+        check_authorization();
+        update_horses();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=29");
+        exit;
+    case 32: // Delete horses
+        check_authorization();
+        delete_horses();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=29");
+        exit;
+    case 33: // Add horses
+        check_authorization();
+        $body = new Template("templates/misc/horses.add.tmpl.php");
+        $body->set("races", $races);
+        $body->set("genders", $genders);
+        break;
+    case 34: // Add horses
+        check_authorization();
+        add_horses();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=29");
+        exit;
+    case 35: // View doors
+        $body = new Template("templates/misc/doors.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $doors = get_doors(1);
+        if ($doors) {
+            foreach ($doors as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 36: // Edit doors
+        check_authorization();
+        $body = new Template("templates/misc/doors.edit.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $body->set('yesno', $yesno);
+        $doors = doors_info();
+        if ($doors) {
+            foreach ($doors as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 37: // Update doors
+        check_authorization();
+        update_doors();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=35");
+        exit;
+    case 38: // Delete doors
+        check_authorization();
+        delete_doors();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=35");
+        exit;
+    case 39: // Get doors ID
+        check_authorization();
+        $body = new Template("templates/misc/doors.add.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $body->set('zid', getZoneID($z));
+        $body->set('suggestdrid', suggest_door_id());
+        $body->set('suggestdoorid', suggest_doorid());
+        $body->set('yesno', $yesno);
+        break;
+    case 40: // Add doors
+        check_authorization();
+        add_doors();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=35");
+        exit;
+    case 41: // View objects
+        $body = new Template("templates/misc/objects.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $body->set("world_containers", $world_containers);
+        $objects = get_objects();
+        if ($objects) {
+            foreach ($objects as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 42: // Edit objects
+        check_authorization();
+        $body = new Template("templates/misc/objects.edit.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $body->set("world_containers", $world_containers);
+        $objects = objects_info();
+        if ($objects) {
+            foreach ($objects as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
+    case 43: // Update objects
+        check_authorization();
+        update_objects();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=41");
+        exit;
+    case 44: // Delete objects
+        check_authorization();
+        delete_objects();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=41");
+        exit;
+    case 45: // Get objects ID
+        check_authorization();
+        $body = new Template("templates/misc/objects.add.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $body->set('zid', getZoneID($z));
+        $body->set("world_containers", $world_containers);
+        $body->set('suggestobjid', suggest_object_id());
+        break;
+    case 46: // Add objects
+        check_authorization();
+        add_objects();
+        header("Location: index.php?editor=misc&z=$z&zoneid=$zoneid&action=41");
+        exit;
+    case 47: // View doors
+        $body = new Template("templates/misc/doors.objects.tmpl.php");
+        $body->set('currzone', $z);
+        $body->set('currzoneid', $zoneid);
+        $doors = get_doors(0);
+        if ($doors) {
+            foreach ($doors as $key => $value) {
+                $body->set($key, $value);
+            }
+        }
+        break;
 }
 
-function get_fishing() {
-  global $mysql, $z;
-  $zid = getZoneID($z);
-  $array = array();
+function get_fishing(): array
+{
+    global $mysql, $z;
+    $zid = getZoneID($z);
+    $array = array();
 
-  $query = "SELECT fishing.id,Itemid AS fiid,zoneid,skill_level,chance, items.name AS name
+    $query = "SELECT fishing.id,Itemid AS fiid,zoneid,skill_level,chance, items.name AS name
                 FROM fishing, items
                 WHERE fishing.zoneid=$zid
                 AND fishing.Itemid=items.id
                 OR fishing.zoneid=0
                 AND fishing.Itemid=items.id";
-  $result = $mysql->query_mult_assoc($query);
-  if ($result) {
-    foreach ($result as $result) {
-     $array['fishing'][$result['id']] = array("fsid"=>$result['id'], "fiid"=>$result['fiid'], "zoneid"=>$result['zoneid'], "skill_level"=>$result['skill_level'], "chance"=>$result['chance'], "name"=>$result['name']);
-         }
-       }
-  return $array;
-  }
+    $results = $mysql->query_mult_assoc($query);
+    if ($results) {
+        foreach ($results as $result) {
+            $array['fishing'][$result['id']] = array("fsid" => $result['id'], "fiid" => $result['fiid'], "zoneid" => $result['zoneid'], "skill_level" => $result['skill_level'], "chance" => $result['chance'], "name" => $result['name']);
+        }
+    }
+    return $array;
+}
 
-function get_forage() {
-  global $mysql, $z;
-  $zid = getZoneID($z);
-  $array = array();
+function get_forage(): array
+{
+    global $mysql, $z;
+    $zid = getZoneID($z);
+    $array = array();
 
-  $query = "SELECT forage.id,zoneid,Itemid AS fgiid,level,chance, items.name AS name
+    $query = "SELECT forage.id,zoneid,Itemid AS fgiid,level,chance, items.name AS name
                 FROM forage, items
                 WHERE forage.zoneid=$zid
                 AND forage.Itemid=items.id
                 OR forage.zoneid=0
                 AND forage.Itemid=items.id";
-  $result = $mysql->query_mult_assoc($query);
-  if ($result) {
-    foreach ($result as $result) {
-     $array['forage'][$result['id']] = array("fgid"=>$result['id'], "fgiid"=>$result['fgiid'], "zoneid"=>$result['zoneid'], "level"=>$result['level'], "chance"=>$result['chance'], "name"=>$result['name']);
-         }
-       }
-  return $array;
-  }
+    $results = $mysql->query_mult_assoc($query);
+    if ($results) {
+        foreach ($results as $result) {
+            $array['forage'][$result['id']] = array("fgid" => $result['id'], "fgiid" => $result['fgiid'], "zoneid" => $result['zoneid'], "level" => $result['level'], "chance" => $result['chance'], "name" => $result['name']);
+        }
+    }
+    return $array;
+}
 
-function get_gspawn() {
-  global $mysql, $z, $zoneid;
-  $zid = getZoneID($z);
-  $array = array();
+function get_gspawn(): array
+{
+    global $mysql, $z;
+    $zid = getZoneID($z);
+    $array = array();
 
-  $query = "SELECT ground_spawns.id,zoneid,max_x,max_y,max_z,min_x,min_y,heading,max_allowed,respawn_timer,item AS giid, items.name AS name
+    $query = "SELECT ground_spawns.id,zoneid,max_x,max_y,max_z,min_x,min_y,heading,max_allowed, ground_spawns.comment As comment, respawn_timer,item AS giid, items.name AS name
                 FROM ground_spawns, items
                 WHERE ground_spawns.zoneid=$zid
                 AND ground_spawns.item=items.id
                 OR ground_spawns.zoneid=0
                 AND ground_spawns.item=items.id";
-  $result = $mysql->query_mult_assoc($query);
-  if ($result) {
-    foreach ($result as $result) {
-     $array['gspawn'][$result['id']] = array("gsid"=>$result['id'], "giid"=>$result['giid'], "zoneid"=>$result['zoneid'], "max_x"=>$result['max_x'], "max_y"=>$result['max_y'], "max_z"=>$result['max_z'], "min_x"=>$result['min_x'], "min_y"=>$result['min_y'], "heading"=>$result['heading'], "gname"=>$result['gname'], "max_allowed"=>$result['max_allowed'], "comment"=>$result['comment'], "respawn_timer"=>$result['respawn_timer'], "iname"=>$result['name']);
-         }
-  }
-
-  return $array;
-  }
-
-function get_traps() {
-  global $mysql, $z, $zoneid;
-  $array = array();
-
-  $query = "SELECT * FROM traps WHERE zone=\"$z\"";
-  $result = $mysql->query_mult_assoc($query);
-  if ($result) {
-    foreach ($result as $result) {
-     $array['traps'][$result['id']] = array("tid"=>$result['id'], "x_coord"=>$result['x'], "y_coord"=>$result['y'], "z_coord"=>$result['z'], "chance"=>$result['chance'], "maxzdiff"=>$result['maxzdiff'], "radius"=>$result['radius'], "effect"=>$result['effect'], "effectvalue"=>$result['effectvalue'], "effectvalue2"=>$result['effectvalue2'], "message"=>$result['message'], "skill"=>$result['skill'], "level"=>$result['level'], "respawn_time"=>$result['respawn_time'], "respawn_var"=>$result['respawn_var'], "group"=>$result['group'], "triggered_number"=>$result['triggered_number'], "despawn_when_triggered"=>$result['despawn_when_triggered'], "undetectable"=>$result['undetectable']);
-         }
-       }
-
-  return $array;
-  }
-
-function get_horses() {
-  global $mysql;
-  $array = array();
-
-  $query = "SELECT * FROM horses";
-  $result = $mysql->query_mult_assoc($query);
-  if ($result) {
-    foreach ($result as $result) {
-     $array['horses'][$result['filename']] = array("filename"=>$result['filename'], "race"=>$result['race'], "gender"=>$result['gender'], "texture"=>$result['texture'], "mountspeed"=>$result['mountspeed'], "notes"=>$result['notes']);
-         }
-       }
-  return $array;
-  }
-
-function get_doors($open) {
-  global $mysql, $z, $zoneid;
-
-  $array = array();
-
-  $query = "SELECT * FROM doors WHERE zone=\"$z\" AND can_open = $open";
-  $result = $mysql->query_mult_assoc($query);
-  if ($result) {
-    foreach ($result as $result) {
-     $array['doors'][$result['id']] = array("drid"=>$result['id'], "doorid"=>$result['doorid'], "name"=>$result['name'], "pos_x"=>$result['pos_x'], "pos_y"=>$result['pos_y'], "pos_z"=>$result['pos_z'], "heading"=>$result['heading'], "opentype"=>$result['opentype'], "lockpick"=>$result['lockpick'], "keyitem"=>$result['keyitem'], "altkeyitem"=>$result['altkeyitem'], "triggerdoor"=>$result['triggerdoor'], "triggertype"=>$result['triggertype'], "doorisopen"=>$result['doorisopen'], "door_param"=>$result['door_param'], "dest_zone"=>$result['dest_zone'], "dest_x"=>$result['dest_x'], "dest_y"=>$result['dest_y'], "dest_z"=>$result['dest_z'], "dest_heading"=>$result['dest_heading'], "invert_state"=>$result['invert_state'], "incline"=>$result['incline'], "size"=>$result['size'], "client_version_mask"=>$result['client_version_mask'], "nokeyring"=>$result['nokeyring'], "islift"=>$result['islift'], "close_time"=>$result['close_time'], "can_open"=>$result['can_open']);
-
+    $results = $mysql->query_mult_assoc($query);
+    if ($results) {
+        foreach ($results as $result) {
+            $array['gspawn'][$result['id']] = array("gsid" => $result['id'], "giid" => $result['giid'], "zoneid" => $result['zoneid'], "max_x" => $result['max_x'], "max_y" => $result['max_y'], "max_z" => $result['max_z'], "min_x" => $result['min_x'], "min_y" => $result['min_y'], "heading" => $result['heading'], "gname" => $result['name'], "max_allowed" => $result['max_allowed'], "comment" => $result['comment'], "respawn_timer" => $result['respawn_timer'], "iname" => $result['name']);
+        }
     }
-  }
-  return $array;
-  }
 
-function get_objects() {
-  global $mysql, $z, $zoneid;
-
-  $zid = getZoneID($z);
-  $array = array();
-
-  $query = "SELECT * FROM object WHERE zoneid=\"$zid\"";
-  $result = $mysql->query_mult_assoc($query);
-  if ($result) {
-    foreach ($result as $result) {
-     $array['objects'][$result['id']] = array("objid"=>$result['id'], "objectname"=>$result['objectname'], "xpos"=>$result['xpos'], "ypos"=>$result['ypos'], "zpos"=>$result['zpos'], "heading"=>$result['heading'], "itemid"=>$result['itemid'], "charges"=>$result['charges'], "type"=>$result['type'], "icon"=>$result['icon']);
-         }
-       }
-  return $array;
-  }
-
-function fishing_info() {
-  global $mysql;
-
-  $fsid = $_GET['fsid'];
-
-  $query = "SELECT id AS fsid,Itemid AS fiid,zoneid,skill_level,chance FROM fishing WHERE id=\"$fsid\"";
-  $result = $mysql->query_assoc($query);
-
-  return $result;
+    return $array;
 }
 
-function forage_info() {
-  global $mysql;
+function get_traps(): array
+{
+    global $mysql, $z;
+    $array = array();
 
-  $fgid = $_GET['fgid'];
+    $query = "SELECT * FROM traps WHERE zone=\"$z\"";
+    $results = $mysql->query_mult_assoc($query);
+    if ($results) {
+        foreach ($results as $result) {
+            $array['traps'][$result['id']] = array("tid" => $result['id'], "x_coord" => $result['x'], "y_coord" => $result['y'], "z_coord" => $result['z'], "chance" => $result['chance'], "maxzdiff" => $result['maxzdiff'], "radius" => $result['radius'], "effect" => $result['effect'], "effectvalue" => $result['effectvalue'], "effectvalue2" => $result['effectvalue2'], "message" => $result['message'], "skill" => $result['skill'], "level" => $result['level'], "respawn_time" => $result['respawn_time'], "respawn_var" => $result['respawn_var'], "group" => $result['group'], "triggered_number" => $result['triggered_number'], "despawn_when_triggered" => $result['despawn_when_triggered'], "undetectable" => $result['undetectable']);
+        }
+    }
 
-  $query = "SELECT id AS fgid,Itemid AS fgiid,zoneid,level,chance FROM forage WHERE id=\"$fgid\"";
-  $result = $mysql->query_assoc($query);
-
-  return $result;
+    return $array;
 }
 
-function gspawn_info() {
-  global $mysql;
+function get_horses(): array
+{
+    global $mysql;
+    $array = array();
 
-  $gsid = $_GET['gsid'];
-
-  $query = "SELECT id AS gsid,zoneid,max_x,max_y,max_z,min_x,min_y,heading,name,item AS giid,max_allowed,comment,respawn_timer FROM ground_spawns WHERE id=\"$gsid\"";
-  $result = $mysql->query_assoc($query);
-
-  return $result;
+    $query = "SELECT * FROM horses";
+    $results = $mysql->query_mult_assoc($query);
+    if ($results) {
+        foreach ($results as $result) {
+            $array['horses'][$result['filename']] = array("filename" => $result['filename'], "race" => $result['race'], "gender" => $result['gender'], "texture" => $result['texture'], "mountspeed" => $result['mountspeed'], "notes" => $result['notes']);
+        }
+    }
+    return $array;
 }
 
-function traps_info() {
-  global $mysql;
+function get_doors($open): array
+{
+    global $mysql, $z;
 
-  $tid = $_GET['tid'];
+    $array = array();
 
-  $query = "SELECT * FROM traps WHERE id=\"$tid\"";
-  $result = $mysql->query_assoc($query);
+    $query = "SELECT * FROM doors WHERE zone=\"$z\" AND can_open = $open";
+    $results = $mysql->query_mult_assoc($query);
+    if ($results) {
+        foreach ($results as $result) {
+            $array['doors'][$result['id']] = array("drid" => $result['id'], "doorid" => $result['doorid'], "name" => $result['name'], "pos_x" => $result['pos_x'], "pos_y" => $result['pos_y'], "pos_z" => $result['pos_z'], "heading" => $result['heading'], "opentype" => $result['opentype'], "lockpick" => $result['lockpick'], "keyitem" => $result['keyitem'], "altkeyitem" => $result['altkeyitem'], "triggerdoor" => $result['triggerdoor'], "triggertype" => $result['triggertype'], "doorisopen" => $result['doorisopen'], "door_param" => $result['door_param'], "dest_zone" => $result['dest_zone'], "dest_x" => $result['dest_x'], "dest_y" => $result['dest_y'], "dest_z" => $result['dest_z'], "dest_heading" => $result['dest_heading'], "invert_state" => $result['invert_state'], "incline" => $result['incline'], "size" => $result['size'], "client_version_mask" => $result['client_version_mask'], "nokeyring" => $result['nokeyring'], "islift" => $result['islift'], "close_time" => $result['close_time'], "can_open" => $result['can_open']);
 
-  return $result;
+        }
+    }
+    return $array;
 }
 
-function horses_info() {
-  global $mysql;
+function get_objects(): array
+{
+    global $mysql, $z;
 
-  $filename = $_GET['filename'];
+    $zid = getZoneID($z);
+    $array = array();
 
-  $query = "SELECT * FROM horses WHERE filename=\"$filename\"";
-  $result = $mysql->query_assoc($query);
-
-  return $result;
+    $query = "SELECT * FROM object WHERE zoneid=\"$zid\"";
+    $results = $mysql->query_mult_assoc($query);
+    if ($results) {
+        foreach ($results as $result) {
+            $array['objects'][$result['id']] = array("objid" => $result['id'], "objectname" => $result['objectname'], "xpos" => $result['xpos'], "ypos" => $result['ypos'], "zpos" => $result['zpos'], "heading" => $result['heading'], "itemid" => $result['itemid'], "charges" => $result['charges'], "type" => $result['type'], "icon" => $result['icon']);
+        }
+    }
+    return $array;
 }
 
-function doors_info() {
-  global $mysql;
+function fishing_info(): bool|array|string|null
+{
+    global $mysql;
 
-  $drid = $_GET['drid'];
+    $fsid = $_GET['fsid'];
 
-  $query = "SELECT * FROM doors WHERE id=\"$drid\"";
-  $result = $mysql->query_assoc($query);
-
-  return $result;
+    $query = "SELECT id AS fsid,Itemid AS fiid,zoneid,skill_level,chance FROM fishing WHERE id=\"$fsid\"";
+    return $mysql->query_assoc($query);
 }
 
-function objects_info() {
-  global $mysql;
+function forage_info(): bool|array|string|null
+{
+    global $mysql;
 
-  $objid = $_GET['objid'];
+    $fgid = $_GET['fgid'];
 
-  $query = "SELECT * FROM object WHERE id=\"$objid\"";
-  $result = $mysql->query_assoc($query);
-
-  return $result;
+    $query = "SELECT id AS fgid,Itemid AS fgiid,zoneid,level,chance FROM forage WHERE id=\"$fgid\"";
+    return $mysql->query_assoc($query);
 }
 
-function update_fishing() {
-  global $mysql;
+function gspawn_info(): bool|array|string|null
+{
+    global $mysql;
 
-  $fsid = $_POST['fsid'];
-  $fiid = $_POST['fiid'];
-  $zoneid = $_POST['zoneid'];
-  $skill_level = $_POST['skill_level'];
-  $chance = $_POST['chance'];
+    $gsid = $_GET['gsid'];
 
-  $query = "UPDATE fishing SET Itemid=\"$fiid\", zoneid=\"$zoneid\", skill_level=\"$skill_level\", chance=\"$chance\" WHERE id=\"$fsid\"";
-  $mysql->query_no_result($query);
+    $query = "SELECT id AS gsid,zoneid,max_x,max_y,max_z,min_x,min_y,heading,name,item AS giid,max_allowed,comment,respawn_timer FROM ground_spawns WHERE id=\"$gsid\"";
+    return $mysql->query_assoc($query);
 }
 
-function update_forage() {
-  global $mysql;
+function traps_info(): bool|array|string|null
+{
+    global $mysql;
 
-  $fgid = $_POST['fgid'];
-  $fgiid = $_POST['fgiid'];
-  $zoneid = $_POST['zoneid'];
-  $level = $_POST['level'];
-  $chance = $_POST['chance'];
+    $tid = $_GET['tid'];
 
-  $query = "UPDATE forage SET Itemid=\"$fgiid\", zoneid=\"$zoneid\", level=\"$level\", chance=\"$chance\" WHERE id=\"$fgid\"";
-  $mysql->query_no_result($query);
+    $query = "SELECT * FROM traps WHERE id=\"$tid\"";
+    return $mysql->query_assoc($query);
 }
 
-function update_horses() {
-  global $mysql;
+function horses_info(): bool|array|string|null
+{
+    global $mysql;
 
-  $filename = $_POST['filename'];
-  $filenamea = $_POST['filenamea'];
-  $race = $_POST['race'];
-  $gender = $_POST['gender'];
-  $texture = $_POST['texture'];
-  $mountspeed = $_POST['mountspeed'];
-  $notes = $_POST['notes'];
+    $filename = $_GET['filename'];
 
-  $query = "UPDATE horses SET filename=\"$filenamea\", race=\"$race\", gender=\"$gender\", texture=\"$texture\", mountspeed=\"$mountspeed\", notes=\"$notes\" WHERE filename=\"$filename\"";
-  $mysql->query_no_result($query);
+    $query = "SELECT * FROM horses WHERE filename=\"$filename\"";
+    return $mysql->query_assoc($query);
 }
 
-function update_gspawn() {
-  global $mysql;
+function doors_info(): bool|array|string|null
+{
+    global $mysql;
 
-  $gsid = $_POST['gsid'];
-  $giid = $_POST['giid'];
-  $zoneid = $_POST['zoneid'];
-  $max_x = $_POST['max_x'];
-  $max_y = $_POST['max_y'];
-  $max_z = $_POST['max_z'];
-  $min_x = $_POST['min_x'];
-  $min_y = $_POST['min_y'];
-  $heading = $_POST['heading'];
-  $max_allowed = $_POST['max_allowed'];
-  $respawn_timer = $_POST['respawn_timer'];
-  $name = $_POST['name'];
-  $comment = $_POST['comment'];
+    $drid = $_GET['drid'];
 
-  $query = "UPDATE ground_spawns SET item=\"$giid\", zoneid=\"$zoneid\", max_x=\"$max_x\", max_y=\"$max_y\", max_z=\"$max_z\", min_x=\"$min_x\", min_y=\"$min_y\", heading=\"$heading\", max_allowed=\"$max_allowed\", respawn_timer=\"$respawn_timer\", name=\"$name\", comment=\"$comment\" 
+    $query = "SELECT * FROM doors WHERE id=\"$drid\"";
+    return $mysql->query_assoc($query);
+}
+
+function objects_info(): bool|array|string|null
+{
+    global $mysql;
+
+    $objid = $_GET['objid'];
+
+    $query = "SELECT * FROM object WHERE id=\"$objid\"";
+    return $mysql->query_assoc($query);
+}
+
+function update_fishing(): void
+{
+    global $mysql;
+
+    $fsid = $_POST['fsid'];
+    $fiid = $_POST['fiid'];
+    $zoneid = $_POST['zoneid'];
+    $skill_level = $_POST['skill_level'];
+    $chance = $_POST['chance'];
+
+    $query = "UPDATE fishing SET Itemid=\"$fiid\", zoneid=\"$zoneid\", skill_level=\"$skill_level\", chance=\"$chance\" WHERE id=\"$fsid\"";
+    $mysql->query_no_result($query);
+}
+
+function update_forage(): void
+{
+    global $mysql;
+
+    $fgid = $_POST['fgid'];
+    $fgiid = $_POST['fgiid'];
+    $zoneid = $_POST['zoneid'];
+    $level = $_POST['level'];
+    $chance = $_POST['chance'];
+
+    $query = "UPDATE forage SET Itemid=\"$fgiid\", zoneid=\"$zoneid\", level=\"$level\", chance=\"$chance\" WHERE id=\"$fgid\"";
+    $mysql->query_no_result($query);
+}
+
+function update_horses(): void
+{
+    global $mysql;
+
+    $filename = $_POST['filename'];
+    $filenamea = $_POST['filenamea'];
+    $race = $_POST['race'];
+    $gender = $_POST['gender'];
+    $texture = $_POST['texture'];
+    $mountspeed = $_POST['mountspeed'];
+    $notes = $_POST['notes'];
+
+    $query = "UPDATE horses SET filename=\"$filenamea\", race=\"$race\", gender=\"$gender\", texture=\"$texture\", mountspeed=\"$mountspeed\", notes=\"$notes\" WHERE filename=\"$filename\"";
+    $mysql->query_no_result($query);
+}
+
+function update_gspawn(): void
+{
+    global $mysql;
+
+    $gsid = $_POST['gsid'];
+    $giid = $_POST['giid'];
+    $zoneid = $_POST['zoneid'];
+    $max_x = $_POST['max_x'];
+    $max_y = $_POST['max_y'];
+    $max_z = $_POST['max_z'];
+    $min_x = $_POST['min_x'];
+    $min_y = $_POST['min_y'];
+    $heading = $_POST['heading'];
+    $max_allowed = $_POST['max_allowed'];
+    $respawn_timer = $_POST['respawn_timer'];
+    $name = $_POST['name'];
+    $comment = $_POST['comment'];
+
+    $query = "UPDATE ground_spawns SET item=\"$giid\", zoneid=\"$zoneid\", max_x=\"$max_x\", max_y=\"$max_y\", max_z=\"$max_z\", min_x=\"$min_x\", min_y=\"$min_y\", heading=\"$heading\", max_allowed=\"$max_allowed\", respawn_timer=\"$respawn_timer\", name=\"$name\", comment=\"$comment\" 
   WHERE id=\"$gsid\"";
-  $mysql->query_no_result($query);
+    $mysql->query_no_result($query);
 }
 
-function update_traps() {
-  global $mysql;
+function update_traps(): void
+{
+    global $mysql;
 
-  $tid = $_POST['tid'];
-  $zone = $_POST['zone'];
-  $x = $_POST['x_coord'];
-  $y = $_POST['y_coord'];
-  $z_coord = $_POST['z_coord'];
-  $chance = $_POST['chance'];
-  $maxzdiff = $_POST['maxzdiff'];
-  $radius = $_POST['radius'];
-  $effect = $_POST['effect'];
-  $effectvalue = $_POST['effectvalue'];
-  $effectvalue2 = $_POST['effectvalue2'];
-  $message = $_POST['message'];
-  $skill = $_POST['skill'];
-  $level = $_POST['level'];
-  $respawn_time = $_POST['respawn_time'];
-  $respawn_var = $_POST['respawn_var'];
-  $group = $_POST['group'];
-  $triggered_number = $_POST['triggered_number'];
-  $despawn_when_triggered = $_POST['despawn_when_triggered'];
-  $undetectable = $_POST['undetectable'];
+    $tid = $_POST['tid'];
+    $zone = $_POST['zone'];
+    $x = $_POST['x_coord'];
+    $y = $_POST['y_coord'];
+    $z_coord = $_POST['z_coord'];
+    $chance = $_POST['chance'];
+    $maxzdiff = $_POST['maxzdiff'];
+    $radius = $_POST['radius'];
+    $effect = $_POST['effect'];
+    $effectvalue = $_POST['effectvalue'];
+    $effectvalue2 = $_POST['effectvalue2'];
+    $message = $_POST['message'];
+    $skill = $_POST['skill'];
+    $level = $_POST['level'];
+    $respawn_time = $_POST['respawn_time'];
+    $respawn_var = $_POST['respawn_var'];
+    $group = $_POST['group'];
+    $triggered_number = $_POST['triggered_number'];
+    $despawn_when_triggered = $_POST['despawn_when_triggered'];
+    $undetectable = $_POST['undetectable'];
 
-  $query = "UPDATE traps SET zone=\"$zone\", x=\"$x\", y=\"$y\", z=\"$z_coord\", chance=\"$chance\", maxzdiff=\"$maxzdiff\", radius=\"$radius\", effect=\"$effect\", effectvalue=\"$effectvalue\", effectvalue2=\"$effectvalue2\", message=\"$message\", skill=\"$skill\", level=\"$level\", respawn_time=\"$respawn_time\", respawn_var=\"$respawn_var\", `group`=\"$group\", triggered_number=\"$triggered_number\", despawn_when_triggered=\"$despawn_when_triggered\", undetectable=\"$undetectable\" WHERE id=\"$tid\"";
-  $mysql->query_no_result($query);
+    $query = "UPDATE traps SET zone=\"$zone\", x=\"$x\", y=\"$y\", z=\"$z_coord\", chance=\"$chance\", maxzdiff=\"$maxzdiff\", radius=\"$radius\", effect=\"$effect\", effectvalue=\"$effectvalue\", effectvalue2=\"$effectvalue2\", message=\"$message\", skill=\"$skill\", level=\"$level\", respawn_time=\"$respawn_time\", respawn_var=\"$respawn_var\", `group`=\"$group\", triggered_number=\"$triggered_number\", despawn_when_triggered=\"$despawn_when_triggered\", undetectable=\"$undetectable\" WHERE id=\"$tid\"";
+    $mysql->query_no_result($query);
 }
 
-function update_doors() {
-  global $mysql;
+function update_doors(): void
+{
+    global $mysql;
 
-  $drid = $_POST['drid'];
-  $doorid = $_POST['doorid'];
-  $name = $_POST['name'];
-  $pos_x = $_POST['pos_x'];
-  $pos_y = $_POST['pos_y'];
-  $pos_z = $_POST['pos_z'];
-  $heading = $_POST['heading'];
-  $opentype = $_POST['opentype'];
-  $lockpick = $_POST['lockpick'];
-  $keyitem = $_POST['keyitem'];
-  $altkeyitem = $_POST['altkeyitem'];
-  $triggerdoor = $_POST['triggerdoor'];
-  $triggertype = $_POST['triggertype'];
-  $doorisopen = $_POST['doorisopen'];
-  $door_param = $_POST['door_param'];
-  $dest_zone = $_POST['dest_zone'];
-  $dest_x = $_POST['dest_x'];
-  $dest_y = $_POST['dest_y'];
-  $dest_z = $_POST['dest_z'];
-  $dest_heading = $_POST['dest_heading'];
-  $invert_state = $_POST['invert_state'];
-  $incline = $_POST['incline'];
-  $size = $_POST['size'];
-  $client_version_mask = $_POST['client_version_mask'];
-  $nokeyring = $_POST['nokeyring'];
-  $islift = $_POST['islift'];
-  $close_time = $_POST['close_time'];
-  $can_open = $_POST['can_open'];
+    $drid = $_POST['drid'];
+    $doorid = $_POST['doorid'];
+    $name = $_POST['name'];
+    $pos_x = $_POST['pos_x'];
+    $pos_y = $_POST['pos_y'];
+    $pos_z = $_POST['pos_z'];
+    $heading = $_POST['heading'];
+    $opentype = $_POST['opentype'];
+    $lockpick = $_POST['lockpick'];
+    $keyitem = $_POST['keyitem'];
+    $altkeyitem = $_POST['altkeyitem'];
+    $triggerdoor = $_POST['triggerdoor'];
+    $triggertype = $_POST['triggertype'];
+    $doorisopen = $_POST['doorisopen'];
+    $door_param = $_POST['door_param'];
+    $dest_zone = $_POST['dest_zone'];
+    $dest_x = $_POST['dest_x'];
+    $dest_y = $_POST['dest_y'];
+    $dest_z = $_POST['dest_z'];
+    $dest_heading = $_POST['dest_heading'];
+    $invert_state = $_POST['invert_state'];
+    $incline = $_POST['incline'];
+    $size = $_POST['size'];
+    $client_version_mask = $_POST['client_version_mask'];
+    $nokeyring = $_POST['nokeyring'];
+    $islift = $_POST['islift'];
+    $close_time = $_POST['close_time'];
+    $can_open = $_POST['can_open'];
 
-  $query = "UPDATE doors SET doorid=\"$doorid\", name=\"$name\", pos_x=\"$pos_x\", pos_y=\"$pos_y\", pos_z=\"$pos_z\", heading=\"$heading\", opentype=\"$opentype\", lockpick=\"$lockpick\", keyitem=\"$keyitem\", altkeyitem=\"$altkeyitem\", triggerdoor=\"$triggerdoor\", triggertype=\"$triggertype\", doorisopen=\"$doorisopen\", door_param=\"$door_param\", dest_zone=\"$dest_zone\", dest_x=\"$dest_x\", dest_y=\"$dest_y\", dest_z=\"$dest_z\", dest_heading=\"$dest_heading\", invert_state=\"$invert_state\", incline=\"$incline\", size=\"$size\", client_version_mask=\"$client_version_mask\", nokeyring=\"$nokeyring\", islift=\"$islift\", close_time=\"$close_time\", can_open=\"$can_open\" WHERE id=\"$drid\"";
-  $mysql->query_no_result($query);
+    $query = "UPDATE doors SET doorid=\"$doorid\", name=\"$name\", pos_x=\"$pos_x\", pos_y=\"$pos_y\", pos_z=\"$pos_z\", heading=\"$heading\", opentype=\"$opentype\", lockpick=\"$lockpick\", keyitem=\"$keyitem\", altkeyitem=\"$altkeyitem\", triggerdoor=\"$triggerdoor\", triggertype=\"$triggertype\", doorisopen=\"$doorisopen\", door_param=\"$door_param\", dest_zone=\"$dest_zone\", dest_x=\"$dest_x\", dest_y=\"$dest_y\", dest_z=\"$dest_z\", dest_heading=\"$dest_heading\", invert_state=\"$invert_state\", incline=\"$incline\", size=\"$size\", client_version_mask=\"$client_version_mask\", nokeyring=\"$nokeyring\", islift=\"$islift\", close_time=\"$close_time\", can_open=\"$can_open\" WHERE id=\"$drid\"";
+    $mysql->query_no_result($query);
 }
 
-function update_objects() {
-  global $mysql;
+function update_objects(): void
+{
+    global $mysql;
 
-  $objid = $_POST['objid'];
-  $objectname = $_POST['objectname'];
-  $xpos = $_POST['xpos'];
-  $ypos = $_POST['ypos'];
-  $zpos = $_POST['zpos'];
-  $heading = $_POST['heading'];
-  $itemid = $_POST['itemid'];
-  $charges = $_POST['charges'];
-  $type = $_POST['type'];
-  $icon = $_POST['icon'];
+    $objid = $_POST['objid'];
+    $objectname = $_POST['objectname'];
+    $xpos = $_POST['xpos'];
+    $ypos = $_POST['ypos'];
+    $zpos = $_POST['zpos'];
+    $heading = $_POST['heading'];
+    $itemid = $_POST['itemid'];
+    $charges = $_POST['charges'];
+    $type = $_POST['type'];
+    $icon = $_POST['icon'];
 
-  $query = "UPDATE object SET objectname=\"$objectname\", xpos=\"$xpos\", ypos=\"$ypos\", zpos=\"$zpos\", heading=\"$heading\", itemid=\"$itemid\", charges=\"$charges\", type=\"$type\", icon=\"$icon\" WHERE id=\"$objid\"";
+    $query = "UPDATE object SET objectname=\"$objectname\", xpos=\"$xpos\", ypos=\"$ypos\", zpos=\"$zpos\", heading=\"$heading\", itemid=\"$itemid\", charges=\"$charges\", type=\"$type\", icon=\"$icon\" WHERE id=\"$objid\"";
 
-  $mysql->query_no_result($query);
+    $mysql->query_no_result($query);
 }
 
-function delete_fishing() {
-  global $mysql;
+function delete_fishing(): void
+{
+    global $mysql;
 
-  $fsid = $_GET['fsid'];
+    $fsid = $_GET['fsid'];
 
-  $query = "DELETE from fishing WHERE id=\"$fsid\"";
-  $mysql->query_no_result($query);
+    $query = "DELETE from fishing WHERE id=\"$fsid\"";
+    $mysql->query_no_result($query);
 }
 
-function delete_forage() {
-  global $mysql;
+function delete_forage(): void
+{
+    global $mysql;
 
-  $fgid = $_GET['fgid'];
+    $fgid = $_GET['fgid'];
 
-  $query = "DELETE from forage WHERE id=\"$fgid\"";
-  $mysql->query_no_result($query);
+    $query = "DELETE from forage WHERE id=\"$fgid\"";
+    $mysql->query_no_result($query);
 }
 
-function delete_gspawn() {
-  global $mysql;
+function delete_gspawn(): void
+{
+    global $mysql;
 
-  $gsid = $_GET['gsid'];
+    $gsid = $_GET['gsid'];
 
-  $query = "DELETE from ground_spawns WHERE id=\"$gsid\"";
-  $mysql->query_no_result($query);
+    $query = "DELETE from ground_spawns WHERE id=\"$gsid\"";
+    $mysql->query_no_result($query);
 }
 
-function delete_traps() {
-  global $mysql;
+function delete_traps(): void
+{
+    global $mysql;
 
-  $tid = $_GET['tid'];
+    $tid = $_GET['tid'];
 
-  $query = "DELETE from traps WHERE id=\"$tid\"";
-  $mysql->query_no_result($query);
+    $query = "DELETE from traps WHERE id=\"$tid\"";
+    $mysql->query_no_result($query);
 }
 
-function delete_horses() {
-  global $mysql;
+function delete_horses(): void
+{
+    global $mysql;
 
-  $filename = $_GET['filename'];
+    $filename = $_GET['filename'];
 
-  $query = "DELETE from horses WHERE filename=\"$filename\"";
-  $mysql->query_no_result($query);
+    $query = "DELETE from horses WHERE filename=\"$filename\"";
+    $mysql->query_no_result($query);
 }
 
-function delete_doors() {
-  global $mysql;
+function delete_doors(): void
+{
+    global $mysql;
 
-  $drid = $_GET['drid'];
+    $drid = $_GET['drid'];
 
-  $query = "DELETE from doors WHERE id=\"$drid\"";
-  $mysql->query_no_result($query);
+    $query = "DELETE from doors WHERE id=\"$drid\"";
+    $mysql->query_no_result($query);
 }
 
-function delete_objects() {
-  global $mysql;
+function delete_objects(): void
+{
+    global $mysql;
 
-  $objid = $_GET['objid'];
+    $objid = $_GET['objid'];
 
-  $query = "DELETE from object WHERE id=\"$objid\"";
-  $mysql->query_no_result($query);
+    $query = "DELETE from object WHERE id=\"$objid\"";
+    $mysql->query_no_result($query);
 }
 
-function suggest_fishing_id() {
-  global $mysql;
+function suggest_fishing_id()
+{
+    global $mysql;
 
-  $query = "SELECT MAX(id) AS fsid FROM fishing";
-  $result = $mysql->query_assoc($query);
+    $query = "SELECT MAX(id) AS fsid FROM fishing";
+    $result = $mysql->query_assoc($query);
 
-  return ($result['fsid'] + 1);
+    return ($result['fsid'] + 1);
 }
 
-function suggest_forage_id() {
-  global $mysql;
+function suggest_forage_id()
+{
+    global $mysql;
 
-  $query = "SELECT MAX(id) AS fgid FROM forage";
-  $result = $mysql->query_assoc($query);
+    $query = "SELECT MAX(id) AS fgid FROM forage";
+    $result = $mysql->query_assoc($query);
 
-  return ($result['fgid'] + 1);
+    return ($result['fgid'] + 1);
 }
 
-function suggest_gspawn_id() {
-  global $mysql;
+function suggest_gspawn_id()
+{
+    global $mysql;
 
-  $query = "SELECT MAX(id) AS gsid FROM ground_spawns";
-  $result = $mysql->query_assoc($query);
+    $query = "SELECT MAX(id) AS gsid FROM ground_spawns";
+    $result = $mysql->query_assoc($query);
 
-  return ($result['gsid'] + 1);
+    return ($result['gsid'] + 1);
 }
 
 
-function suggest_traps_id() {
-  global $mysql;
+function suggest_traps_id()
+{
+    global $mysql;
 
-  $query = "SELECT MAX(id) AS tid FROM traps";
-  $result = $mysql->query_assoc($query);
+    $query = "SELECT MAX(id) AS tid FROM traps";
+    $result = $mysql->query_assoc($query);
 
-  return ($result['tid'] + 1);
+    return ($result['tid'] + 1);
 }
 
-function suggest_door_id() {
-  global $mysql;
+function suggest_door_id()
+{
+    global $mysql;
 
-  $query = "SELECT MAX(id) AS drid FROM doors";
-  $result = $mysql->query_assoc($query);
+    $query = "SELECT MAX(id) AS drid FROM doors";
+    $result = $mysql->query_assoc($query);
 
-  return ($result['drid'] + 1);
+    return ($result['drid'] + 1);
 }
 
-function suggest_doorid() {
-  global $mysql, $z;
+function suggest_doorid()
+{
+    global $mysql, $z;
 
-  $query = "SELECT MAX(doorid) AS dorid FROM doors WHERE zone=\"$z\"";
-  $result = $mysql->query_assoc($query);
+    $query = "SELECT MAX(doorid) AS dorid FROM doors WHERE zone=\"$z\"";
+    $result = $mysql->query_assoc($query);
 
-  return ($result['dorid'] + 1);
+    return ($result['dorid'] + 1);
 }
 
-function suggest_object_id() {
-  global $mysql;
+function suggest_object_id()
+{
+    global $mysql;
 
-  $query = "SELECT MAX(id) AS objid FROM object";
-  $result = $mysql->query_assoc($query);
+    $query = "SELECT MAX(id) AS objid FROM object";
+    $result = $mysql->query_assoc($query);
 
-  return ($result['objid'] + 1);
+    return ($result['objid'] + 1);
 }
 
-function add_fishing() {
-  global $mysql;
+function add_fishing(): void
+{
+    global $mysql;
 
-  $fsid = $_GET['fsid'];
-  $fiid = $_POST['fiid'];
-  $zoneid = $_POST['zoneid'];
-  $skill_level = $_POST['skill_level'];
-  $chance = $_POST['chance'];
+    $fiid = $_POST['fiid'];
+    $zoneid = $_POST['zoneid'];
+    $skill_level = $_POST['skill_level'];
+    $chance = $_POST['chance'];
 
-  $query = "INSERT INTO fishing SET id=\"fsid\", Itemid=\"$fiid\", zoneid=\"$zoneid\", skill_level=\"$skill_level\", chance=\"$chance\"";
-  $mysql->query_no_result($query);
+    $query = "INSERT INTO fishing SET id=\"fsid\", Itemid=\"$fiid\", zoneid=\"$zoneid\", skill_level=\"$skill_level\", chance=\"$chance\"";
+    $mysql->query_no_result($query);
 }
 
-function add_forage() {
-  global $mysql;
+function add_forage(): void
+{
+    global $mysql;
 
-  $fgid = $_GET['fgid'];
-  $fgiid = $_POST['fgiid'];
-  $zoneid = $_POST['zoneid'];
-  $level = $_POST['level'];
-  $chance = $_POST['chance'];
+    $fgiid = $_POST['fgiid'];
+    $zoneid = $_POST['zoneid'];
+    $level = $_POST['level'];
+    $chance = $_POST['chance'];
 
-  $query = "INSERT INTO forage SET id=\"fgid\", Itemid=\"$fgiid\", zoneid=\"$zoneid\", level=\"$level\", chance=\"$chance\"";
-  $mysql->query_no_result($query);
+    $query = "INSERT INTO forage SET id=\"fgid\", Itemid=\"$fgiid\", zoneid=\"$zoneid\", level=\"$level\", chance=\"$chance\"";
+    $mysql->query_no_result($query);
 }
 
-function add_gspawn() {
-  global $mysql;
+function add_gspawn(): void
+{
+    global $mysql;
 
-  $gsid = $_POST['gsid'];
-  $giid = $_POST['giid'];
-  $zoneid = $_POST['zoneid'];
-  $max_x = $_POST['max_x'];
-  $max_y = $_POST['max_y'];
-  $max_z = $_POST['max_z'];
-  $min_x = $_POST['min_x'];
-  $min_y = $_POST['min_y'];
-  $heading = $_POST['heading'];
-  $max_allowed = $_POST['max_allowed'];
-  $respawn_timer = $_POST['respawn_timer'];
-  $name = $_POST['name'];
-  $comment = $_POST['comment'];
+    $gsid = $_POST['gsid'];
+    $giid = $_POST['giid'];
+    $zoneid = $_POST['zoneid'];
+    $max_x = $_POST['max_x'];
+    $max_y = $_POST['max_y'];
+    $max_z = $_POST['max_z'];
+    $min_x = $_POST['min_x'];
+    $min_y = $_POST['min_y'];
+    $heading = $_POST['heading'];
+    $max_allowed = $_POST['max_allowed'];
+    $respawn_timer = $_POST['respawn_timer'];
+    $name = $_POST['name'];
+    $comment = $_POST['comment'];
 
-  $query = "INSERT INTO ground_spawns SET id=\"$gsid\", item=\"$giid\", zoneid=\"$zoneid\", max_x=\"$max_x\", max_y=\"$max_y\", max_z=\"$max_z\", min_x=\"$min_x\", min_y=\"$min_y\", heading=\"$heading\", max_allowed=\"$max_allowed\", respawn_timer=\"$respawn_timer\", name=\"$name\", comment=\"$comment\"";
-  $mysql->query_no_result($query);
+    $query = "INSERT INTO ground_spawns SET id=\"$gsid\", item=\"$giid\", zoneid=\"$zoneid\", max_x=\"$max_x\", max_y=\"$max_y\", max_z=\"$max_z\", min_x=\"$min_x\", min_y=\"$min_y\", heading=\"$heading\", max_allowed=\"$max_allowed\", respawn_timer=\"$respawn_timer\", name=\"$name\", comment=\"$comment\"";
+    $mysql->query_no_result($query);
 }
 
-function add_traps() {
-  global $mysql;
+function add_traps(): void
+{
+    global $mysql;
 
-  $tid = $_POST['tid'];
-  $zone = $_POST['zone'];
-  $x = $_POST['x_coord'];
-  $y = $_POST['y_coord'];
-  $z_coord = $_POST['z_coord'];
-  $chance = $_POST['chance'];
-  $maxzdiff = $_POST['maxzdiff'];
-  $radius = $_POST['radius'];
-  $effect = $_POST['effect'];
-  $effectvalue = $_POST['effectvalue'];
-  $effectvalue2 = $_POST['effectvalue2'];
-  $message = $_POST['message'];
-  $skill = $_POST['skill'];
-  $level = $_POST['level'];
-  $respawn_time = $_POST['respawn_time'];
-  $respawn_var = $_POST['respawn_var'];
-  $group = $_POST['group'];
-  $triggered_number = $_POST['triggered_number'];
-  $despawn_when_triggered = $_POST['despawn_when_triggered'];
-  $undetectable = $_POST['undetectable'];
+    $tid = $_POST['tid'];
+    $zone = $_POST['zone'];
+    $x = $_POST['x_coord'];
+    $y = $_POST['y_coord'];
+    $z_coord = $_POST['z_coord'];
+    $chance = $_POST['chance'];
+    $maxzdiff = $_POST['maxzdiff'];
+    $radius = $_POST['radius'];
+    $effect = $_POST['effect'];
+    $effectvalue = $_POST['effectvalue'];
+    $effectvalue2 = $_POST['effectvalue2'];
+    $message = $_POST['message'];
+    $skill = $_POST['skill'];
+    $level = $_POST['level'];
+    $respawn_time = $_POST['respawn_time'];
+    $respawn_var = $_POST['respawn_var'];
+    $group = $_POST['group'];
+    $triggered_number = $_POST['triggered_number'];
+    $despawn_when_triggered = $_POST['despawn_when_triggered'];
+    $undetectable = $_POST['undetectable'];
 
-  $query = "INSERT INTO traps SET id=\"$tid\", zone=\"$zone\", x=\"$x\", y=\"$y\", z=\"$z_coord\", chance=\"$chance\", maxzdiff=\"$maxzdiff\", radius=\"$radius\", effect=\"$effect\", effectvalue=\"$effectvalue\", effectvalue2=\"$effectvalue2\", message=\"$message\", skill=\"$skill\", level=\"$level\", respawn_time=\"$respawn_time\", respawn_var=\"$respawn_var\", `group`=\"$group\", triggered_number=\"$triggered_number\", despawn_when_triggered=\"$despawn_when_triggered\", undetectable=\"$undetectable\"";
-  $mysql->query_no_result($query);
+    $query = "INSERT INTO traps SET id=\"$tid\", zone=\"$zone\", x=\"$x\", y=\"$y\", z=\"$z_coord\", chance=\"$chance\", maxzdiff=\"$maxzdiff\", radius=\"$radius\", effect=\"$effect\", effectvalue=\"$effectvalue\", effectvalue2=\"$effectvalue2\", message=\"$message\", skill=\"$skill\", level=\"$level\", respawn_time=\"$respawn_time\", respawn_var=\"$respawn_var\", `group`=\"$group\", triggered_number=\"$triggered_number\", despawn_when_triggered=\"$despawn_when_triggered\", undetectable=\"$undetectable\"";
+    $mysql->query_no_result($query);
 }
 
-function add_horses() {
-  global $mysql;
+function add_horses(): void
+{
+    global $mysql;
 
-  $filename = $_POST['filename'];
-  $race = $_POST['race'];
-  $gender = $_POST['gender'];
-  $texture = $_POST['texture'];
-  $mountspeed = $_POST['mountspeed'];
-  $notes = $_POST['notes'];
+    $filename = $_POST['filename'];
+    $race = $_POST['race'];
+    $gender = $_POST['gender'];
+    $texture = $_POST['texture'];
+    $mountspeed = $_POST['mountspeed'];
+    $notes = $_POST['notes'];
 
-  $query = "INSERT INTO horses SET filename=\"$filename\", race=\"$race\", gender=\"$gender\", texture=\"$texture\", mountspeed=\"$mountspeed\", notes=\"$notes\"";
-  $mysql->query_no_result($query);
+    $query = "INSERT INTO horses SET filename=\"$filename\", race=\"$race\", gender=\"$gender\", texture=\"$texture\", mountspeed=\"$mountspeed\", notes=\"$notes\"";
+    $mysql->query_no_result($query);
 }
 
-function add_doors() {
-  global $mysql, $z;
+function add_doors(): void
+{
+    global $mysql, $z;
 
-  $drid = $_POST['drid'];
-  $doorid = $_POST['doorid'];
-  $name = $_POST['name'];
-  $pos_x = $_POST['pos_x'];
-  $pos_y = $_POST['pos_y'];
-  $pos_z = $_POST['pos_z'];
-  $heading = $_POST['heading'];
-  $opentype = $_POST['opentype'];
-  $lockpick = $_POST['lockpick'];
-  $keyitem = $_POST['keyitem'];
-  $altkeyitem = $_POST['altkeyitem'];
-  $triggerdoor = $_POST['triggerdoor'];
-  $triggertype = $_POST['triggertype'];
-  $doorisopen = $_POST['doorisopen'];
-  $door_param = $_POST['door_param'];
-  $dest_zone = $_POST['dest_zone'];
-  $dest_x = $_POST['dest_x'];
-  $dest_y = $_POST['dest_y'];
-  $dest_z = $_POST['dest_z'];
-  $dest_heading = $_POST['dest_heading'];
-  $invert_state = $_POST['invert_state'];
-  $incline = $_POST['incline'];
-  $size = $_POST['size'];
-  $client_version_mask = $_POST['client_version_mask'];
-  $nokeyring = $_POST['nokeyring'];
-  $islift = $_POST['islift'];
-  $close_time = $_POST['close_time'];
-  $can_open = $_POST['can_open'];
+    $drid = $_POST['drid'];
+    $doorid = $_POST['doorid'];
+    $name = $_POST['name'];
+    $pos_x = $_POST['pos_x'];
+    $pos_y = $_POST['pos_y'];
+    $pos_z = $_POST['pos_z'];
+    $heading = $_POST['heading'];
+    $opentype = $_POST['opentype'];
+    $lockpick = $_POST['lockpick'];
+    $keyitem = $_POST['keyitem'];
+    $altkeyitem = $_POST['altkeyitem'];
+    $triggerdoor = $_POST['triggerdoor'];
+    $triggertype = $_POST['triggertype'];
+    $doorisopen = $_POST['doorisopen'];
+    $door_param = $_POST['door_param'];
+    $dest_zone = $_POST['dest_zone'];
+    $dest_x = $_POST['dest_x'];
+    $dest_y = $_POST['dest_y'];
+    $dest_z = $_POST['dest_z'];
+    $dest_heading = $_POST['dest_heading'];
+    $invert_state = $_POST['invert_state'];
+    $incline = $_POST['incline'];
+    $size = $_POST['size'];
+    $client_version_mask = $_POST['client_version_mask'];
+    $nokeyring = $_POST['nokeyring'];
+    $islift = $_POST['islift'];
+    $close_time = $_POST['close_time'];
+    $can_open = $_POST['can_open'];
 
-  $query = "INSERT INTO doors SET id=\"$drid\", zone=\"$z\", doorid=\"$doorid\", name=\"$name\", pos_x=\"$pos_x\", pos_y=\"$pos_y\", pos_z=\"$pos_z\", heading=\"$heading\", opentype=\"$opentype\", lockpick=\"$lockpick\", keyitem=\"$keyitem\", altkeyitem=\"$altkeyitem\", triggerdoor=\"$triggerdoor\", triggertype=\"$triggertype\", doorisopen=\"$doorisopen\", door_param=\"$door_param\", dest_zone=\"$dest_zone\", dest_x=\"$dest_x\", dest_y=\"$dest_y\", dest_z=\"$dest_z\", dest_heading=\"$dest_heading\", invert_state=\"$invert_state\", incline=\"$incline\", size=\"$size\", client_version_mask=\"$client_version_mask\", nokeyring=\"$nokeyring\", islift=\"$islift\", close_time=\"$close_time\", can_open=\"$can_open\"";
-  $mysql->query_no_result($query);
+    $query = "INSERT INTO doors SET id=\"$drid\", zone=\"$z\", doorid=\"$doorid\", name=\"$name\", pos_x=\"$pos_x\", pos_y=\"$pos_y\", pos_z=\"$pos_z\", heading=\"$heading\", opentype=\"$opentype\", lockpick=\"$lockpick\", keyitem=\"$keyitem\", altkeyitem=\"$altkeyitem\", triggerdoor=\"$triggerdoor\", triggertype=\"$triggertype\", doorisopen=\"$doorisopen\", door_param=\"$door_param\", dest_zone=\"$dest_zone\", dest_x=\"$dest_x\", dest_y=\"$dest_y\", dest_z=\"$dest_z\", dest_heading=\"$dest_heading\", invert_state=\"$invert_state\", incline=\"$incline\", size=\"$size\", client_version_mask=\"$client_version_mask\", nokeyring=\"$nokeyring\", islift=\"$islift\", close_time=\"$close_time\", can_open=\"$can_open\"";
+    $mysql->query_no_result($query);
 }
 
-function add_objects() {
-  global $mysql, $z;
+function add_objects(): void
+{
+    global $mysql, $z;
 
-  $zid = getZoneID($z);
-  $objid = $_POST['objid'];
-  $zoneid = $_POST['zoneid'];
-  $objectname = $_POST['objectname'];
-  $xpos = $_POST['xpos'];
-  $ypos = $_POST['ypos'];
-  $zpos = $_POST['zpos'];
-  $heading = $_POST['heading'];
-  $itemid = $_POST['itemid'];
-  $charges = $_POST['charges'];
-  $type = $_POST['type'];
-  $icon = $_POST['icon'];
+    $zid = getZoneID($z);
+    $objid = $_POST['objid'];
+    $objectname = $_POST['objectname'];
+    $xpos = $_POST['xpos'];
+    $ypos = $_POST['ypos'];
+    $zpos = $_POST['zpos'];
+    $heading = $_POST['heading'];
+    $itemid = $_POST['itemid'];
+    $charges = $_POST['charges'];
+    $type = $_POST['type'];
+    $icon = $_POST['icon'];
 
-  $query = "INSERT INTO object SET id=\"$objid\", zoneid=\"$zid\", objectname=\"$objectname\", xpos=\"$xpos\", ypos=\"$ypos\", zpos=\"$zpos\", heading=\"$heading\", itemid=\"$itemid\", charges=\"$charges\", type=\"$type\", icon=\"$icon\"";
+    $query = "INSERT INTO object SET id=\"$objid\", zoneid=\"$zid\", objectname=\"$objectname\", xpos=\"$xpos\", ypos=\"$ypos\", zpos=\"$zpos\", heading=\"$heading\", itemid=\"$itemid\", charges=\"$charges\", type=\"$type\", icon=\"$icon\"";
 
-  $mysql->query_no_result($query);
+    $mysql->query_no_result($query);
 }
 
-function search_fishing_by_id() {
-   global $mysql;
+function search_fishing_by_id(): array|string|null
+{
+    global $mysql;
 
-   $fishid = $_GET['fishid'];
+    $fishid = $_GET['fishid'];
 
-   $query = "SELECT id AS fsid, Itemid AS fiid FROM fishing WHERE Itemid=\"$fishid\"";
-   $results = $mysql->query_mult_assoc($query);
-
-   return $results;
+    $query = "SELECT id AS fsid, Itemid AS fiid FROM fishing WHERE Itemid=\"$fishid\"";
+    return $mysql->query_mult_assoc($query);
 }
 
-function search_gspawn_by_id() {
-   global $mysql;
+function search_gspawn_by_id(): array|string|null
+{
+    global $mysql;
 
-   $gspawnid = $_GET['gspawnid'];
+    $gspawnid = $_GET['gspawnid'];
 
-   $query = "SELECT id AS gsid, item AS giid FROM ground_spawns where item=\"$gspawnid\"";
-   $results = $mysql->query_mult_assoc($query);
-
-   return $results;
+    $query = "SELECT id AS gsid, item AS giid FROM ground_spawns where item=\"$gspawnid\"";
+    return $mysql->query_mult_assoc($query);
 }
 
-function search_forage_by_id() {
-   global $mysql;
+function search_forage_by_id(): array|string|null
+{
+    global $mysql;
 
-   $forageid = $_GET['forageid'];
+    $forageid = $_GET['forageid'];
 
-   $query = "SELECT id AS fgid, Itemid AS fgiid FROM forage where Itemid=\"$forageid\"";
-   $results = $mysql->query_mult_assoc($query);
-
-   return $results;
+    $query = "SELECT id AS fgid, Itemid AS fgiid FROM forage where Itemid=\"$forageid\"";
+    return $mysql->query_mult_assoc($query);
 }
 
 ?>

--- a/lib/util.php
+++ b/lib/util.php
@@ -58,7 +58,7 @@ switch ($action) {
         $javascript = new Template("templates/util/js.tmpl.php");
         $body = new Template("templates/util/util.recipes.tmpl.php");
         $count = $default_count;
-        if ($_GET['count'] > 0) {
+        if (isset($_GET['count']) && $_GET['count'] > 0) {
             $count = $_GET['count'];
         }
         $body->set('count', $count);
@@ -81,7 +81,7 @@ function purge_characters(): void
 {
     $characters = $_POST['id'];
 
-    foreach ($characters as $character => $id) {
+    foreach ($characters as ($char) => $id) {
         delete_player($id);
     }
 }
@@ -98,7 +98,7 @@ function purge_accounts(): void
 {
     $accounts = $_POST['id'];
 
-    foreach ($accounts as $account => $id) {
+    foreach ($accounts as ($account) => $id) {
         delete_account($id);
     }
 }

--- a/templates/misc/doors.add.tmpl.php
+++ b/templates/misc/doors.add.tmpl.php
@@ -1,99 +1,139 @@
 <div class="edit_form" style="width: 750px">
-      <div class="edit_form_header">
+    <div class="edit_form_header">
         Add Door
-      </div>
-      <div class="edit_form_content">
-        <form name="door" method="post" action=index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=40">
-        <table width="100%">
-          <tr>
-            <th>id</th>
-            <th>doorid</th>
-            <th>name</th>
-            <th>x</th>
-            <th>y</th>
-            <th>z</th>
-            <th>heading</th>
-            <th>opentype</th>
-          </tr>
-          <tr>
-            <td><input type="text" size="7" name="drid" value="<?=$suggestdrid?>"></td>
-            <td><input type="text" size="7" name="doorid" value="<?=$suggestdoorid?>"></td>
-            <td><input type="text" size="15" name="name" value=""></td>
-            <td><input type="text" size="7" name="pos_x" value="0"></td>
-            <td><input type="text" size="7" name="pos_y" value="0"></td>
-            <td><input type="text" size="7" name="pos_z" value="0"></td>
-            <td><input type="text" size="7" name="heading" value="0"></td>
-            <td><input type="text" size="7" name="opentype" value="0"></td>
-           </tr>
-          <tr>
-            <th>size</th>
-            <th>dest zone</th>
-            <th>dest x</th>
-            <th>dest y</th>
-            <th>dest z</th>
-            <th>dest heading</th>
-            <th>lockpick</th>
-            <th>client</th>
-          </tr>
-          <tr>
-            <td><input type="text" size="7" name="size" value="100"></td>
-            <td><input type="text" size="15" name="dest_zone" value="NONE"></td>
-            <td><input type="text" size="7" name="dest_x" value="0"></td>
-            <td><input type="text" size="7" name="dest_y" value="0"></td>
-            <td><input type="text" size="7" name="dest_z" value="0"></td>
-            <td><input type="text" size="7" name="dest_heading" value="0"></td>
-            <td><input type="text" size="7" name="lockpick" value="0"></td>
-            <td><input type="text" size="10" name="client_version_mask" value="4294967295"></td>
-          </tr>
-          <tr>
-            <th>triggerdoor</th>
-            <th>triggertype</th>
-            <th>param</th>
-            <th>doorisopen</th>
-            <th>invert</th>
-            <th>incline</th>
-            <th>keyitem</th>
-            <th>altkeyitem</th>
-         </tr>
-          <tr>
-            <td><input type="text" size="7" name="triggerdoor" value="0"></td>
-            <td><input type="text" size="7" name="triggertype" value="0"></td>
-            <td><input type="text" size="7" name="door_param" value="0"></td>
-            <td><input type="text" size="7" name="doorisopen" value="0"></td>
-            <td><input type="text" size="7" name="invert_state" value="0"></td>
-            <td><input type="text" size="7" name="incline" value="0"></td>
-            <td><input type="text" size="7" name="keyitem" value="0"></td>
-            <td><input type="text" size="7" name="altkeyitem" value="0"></td>
-
-         </tr>
-         <tr>
-            <th>nokeyring</th>
-            <th>islift</th>
-            <th>close_time</th>
-            <th>can_open</th>
-         </tr>
-          <tr>
-            <td><select class="left" name="nokeyring">
-<?foreach($yesno as $k => $v):?>
-              <option value="<?=$k?>"<? echo ($k == $nokeyring) ? " selected" : ""?>><?=$v?></option>
-<?$x++; endforeach;?>
-           </td>
-          <td><select class="left" name="islift">
-<?foreach($yesno as $k => $v):?>
-              <option value="<?=$k?>"<? echo ($k == $islift) ? " selected" : ""?>><?=$v?></option>
-<?$x++; endforeach;?>
-           </td>
-          <td><input type="text" size="7" name="close_time" value="5"></td>
-          <td><select class="left" name="can_open">
-<?foreach($yesno as $k => $v):?>
-              <option value="<?=$k?>"<? echo ($k == $can_open) ? " selected" : ""?>><?=$v?></option>
-<?$x++; endforeach;?>
-           </td>
-         </tr>
-              </table><br><br>
-        <center>
-          <input type="submit" value="Submit Changes">
-        </center>
-      </form>
-      </div>
-      </div>
+    </div>
+    <div class="edit_form_content">
+        <form name="door" method="post"
+              action=index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=40">
+            <div style="padding-bottom:20px;">
+                <fieldset>
+                    <legend>Identity</legend>
+                    <table style="width: 100%; border-spacing: 20px;">
+                        <tr>
+                            <th colspan="2"><label for="name">Door Name</label></th>
+                            <th colspan="2"><label for="drid">suggested id</label></th>
+                            <th colspan="2"><label for="doorid">suggested doorid</label></th>
+                            <th colspan="2"><label for="client_version_mask">client version mask</label></th>
+                        </tr>
+                        <tr>
+                            <td colspan="2" style="padding-top: 5px;"><input type="text" size="15" id="name" name="name" value=""></td>
+                            <td colspan="2" style="padding-top: 5px;"><input type="text" size="7" id="drid" name="drid" value="<?= $suggestdrid ?? "" ?>"></td>
+                            <td colspan="2" style="padding-top: 5px;"><input type="text" size="7" id="doorid" name="doorid" value="<?= $suggestdoorid ?? "" ?>"></td>
+                            <td colspan="2" style="padding-top: 5px;"><input type="text" size="10" id="client_version_mask" name="client_version_mask" value="4294967295"></td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div style="padding-bottom:20px;">
+                <fieldset>
+                    <legend>Location Data</legend>
+                    <table style="width: 100%; border-spacing: 20px;">
+                        <tr>
+                            <th colspan="2"><label for="curr_zone">curr zone (shortname)</label></th>
+                            <th colspan="2"><label for="pos_x">x</label></th>
+                            <th colspan="2"><label for="pos_y">y</label></th>
+                            <th colspan="2"><label for="pos_z">z</label></th>
+                            <th colspan="2"><label for="heading">heading</label></th>
+                        </tr>
+                        <tr>
+                            <td colspan="2" style="padding-top: 5px;"><input type="text" size="15" id="curr_zone" name="curr_zone" disabled value="<?= $currzone ?? "" ?>"></td>
+                            <td colspan="2" style="padding-top: 5px;"><input type="text" size="7" id="pos_x" name="pos_x" value="0"></td>
+                            <td colspan="2" style="padding-top: 5px;"><input type="text" size="7" id="pos_y" name="pos_y" value="0"></td>
+                            <td colspan="2" style="padding-top: 5px;"><input type="text" size="7" id="pos_z" name="pos_z" value="0"></td>
+                            <td colspan="2" style="padding-top: 5px;"><input type="text" size="7" id="heading" name="heading" value="0"></td>
+                        </tr>
+                        <tr>
+                            <th colspan="2"><label for="dest_zone">dest zone (shortname)</label></th>
+                            <th colspan="2"><label for="dest_x">dest x</label></th>
+                            <th colspan="2"><label for="dest_y">dest y</label></th>
+                            <th colspan="2"><label for="dest_z">dest z</label></th>
+                            <th colspan="2"><label for="dest_heading">dest heading</label></th>
+                        </tr>
+                        <tr>
+                            <td colspan="2"><input type="text" size="15" id="dest_zone" name="dest_zone" value="NONE"></td>
+                            <td colspan="2"><input type="text" size="7" id="dest_x" name="dest_x" value="0"></td>
+                            <td colspan="2"><input type="text" size="7" id="dest_y" name="dest_y" value="0"></td>
+                            <td colspan="2"><input type="text" size="7" id="dest_z" name="dest_z" value="0"></td>
+                            <td><input type="text" size="7" id="dest_heading" name="dest_heading" value="0"></td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div style="padding-bottom:20px;">
+                <fieldset>
+                    <legend>Door Characteristics</legend>
+                    <table style="width: 100%; border-spacing: 20px;">
+                        <tr>
+                            <th colspan="2"><label for="opentype">opentype</label></th>
+                            <th colspan="2"><label for="doorisopen">doorisopen</label></th>
+                            <th colspan="2"><label for="can_open">can_open</label></th>
+                            <th colspan="2"><label for="islift">islift</label></th>
+                        </tr>
+                        <tr>
+                            <td colspan="2" style="padding-top: 5px;"><input type="text" size="7" id="opentype" name="opentype" value="0"></td>
+                            <td colspan="2"><input type="text" size="7" id="doorisopen" name="doorisopen" value="0"></td>
+                            <td colspan="2"><select class="left" id="can_open" name="can_open">
+                                    <?php foreach ($yesno as $k => $v): ?>
+                                        <option value="<?= $k ?>"<?php echo (isset($can_open) && $k == $can_open) ? " selected" : "" ?>><?= $v ?></option>
+                                        <?php $x++; endforeach; ?>
+                            </td>
+                            <td colspan="2"><select class="left" id="islift" name="islift">
+                                    <?php foreach ($yesno as $k => $v): ?>
+                                        <option value="<?= $k ?>"<?php echo (isset($islift) && $k == $islift) ? " selected" : "" ?>><?= $v ?></option>
+                                        <?php $x++; endforeach; ?>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th colspan="2"><label for="triggerdoor">triggerdoor</label></th>
+                            <th colspan="2"><label for="triggertype">triggertype</label></th>
+                            <th colspan="2"><label for="door_param">param</label></th>
+                            <th colspan="2"><label for="invert_state">invert</label></th>
+                            <th colspan="2"><label for="incline">incline</label></th>
+                        </tr>
+                        <tr>
+                            <td colspan="2"><input type="text" size="7" id="triggerdoor" name="triggerdoor" value="0"></td>
+                            <td colspan="2"><input type="text" size="7" id="triggertype" name="triggertype" value="0"></td>
+                            <td colspan="2"><input type="text" size="7" id="door_param" name="door_param" value="0"></td>
+                            <td colspan="2"><input type="text" size="7" id="invert_state" name="invert_state" value="0"></td>
+                            <td colspan="2"><input type="text" size="7" id="incline" name="incline" value="0"></td>
+                        </tr>
+                        <tr>
+                            <th colspan="2"><label for="close_time">close_time</label></th>
+                            <th colspan="2"><label for="size">size</label></th>
+                        </tr>
+                        <tr>
+                            <td colspan="2"><input type="text" size="7" id="close_time" name="close_time" value="5"></td>
+                            <td colspan="2" style="padding-top: 5px;"><input type="text" size="7" id="size" name="size" value="100"></td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div style="padding-bottom:20px;">
+                <fieldset>
+                    <legend>Access Control</legend>
+                    <table style="width: 100%; border-spacing: 20px;">
+                        <tr>
+                            <th colspan="2"><label for="nokeyring">nokeyring</label></th>
+                            <th colspan="2"><label for="lockpick">lockpick</label></th>
+                            <th colspan="2"><label for="keyitem">key item id</label></th>
+                            <th colspan="2"><label for="altkeyitem">alt key item id</label></th>
+                        </tr>
+                        <tr>
+                            <td colspan="2"><select class="left" id="nokeyring" name="nokeyring">
+                                    <?php foreach ($yesno as $k => $v): ?>
+                                        <option value="<?= $k ?>"<?php echo (isset($nokeyring) && $k == $nokeyring) ? " selected" : "" ?>><?= $v ?></option>
+                                        <?php $x++; endforeach; ?>
+                            </td>
+                            <td colspan="2" style="padding-top: 5px;"><input type="text" size="7" id="lockpick" name="lockpick" value="0"></td>
+                            <td colspan="2"><input type="text" size="7" id="keyitem" name="keyitem" value="0"></td>
+                            <td colspan="2"><input type="text" size="7" id="altkeyitem" name="altkeyitem" value="0"></td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div class="center">
+                <input type="submit" value="Submit Changes">
+            </div>
+        </form>
+    </div>
+</div>

--- a/templates/misc/doors.edit.tmpl.php
+++ b/templates/misc/doors.edit.tmpl.php
@@ -1,98 +1,169 @@
 <div class="edit_form" style="width: 750px">
-      <div class="edit_form_header">
-        Door: <?=$id?>
-      </div>
-
-      <div class="edit_form_content">
-        <form name="door" method="post" action=index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=37">
-        <table width="100%">
-          <tr>
-            <th>doorid</th>
-            <th>name</th>
-            <th>x</th>
-            <th>y</th>
-            <th>z</th>
-            <th>heading</th>
-            <th>opentype</th>
-            <th>client</th>
-          </tr>
-          <tr>
-            <td><input type="text" size="7" name="doorid" value="<?=$doorid?>"></td>
-            <td><input type="text" size="15" name="name" value="<?=$name?>"></td>
-            <td><input type="text" size="7" name="pos_x" value="<?=$pos_x?>"></td>
-            <td><input type="text" size="7" name="pos_y" value="<?=$pos_y?>"></td>
-            <td><input type="text" size="7" name="pos_z" value="<?=$pos_z?>"></td>
-            <td><input type="text" size="7" name="heading" value="<?=$heading?>"></td>
-            <td><input type="text" size="7" name="opentype" value="<?=$opentype?>"></td>
-            <td><input type="text" size="10" name="client_version_mask" value="<?=$client_version_mask?>"></td>
-           </tr>
-          <tr>
-          	<th>lockpick</th>
-            <th>dest zone</th>
-            <th>dest x</th>
-            <th>dest y</th>
-            <th>dest z</th>
-            <th>dest heading</th>
-            <th>keyitem</th>
-            <th>altkeyitem</th>
-          </tr>
-          <tr>
-			<td><input type="text" size="7" name="lockpick" value="<?=$lockpick?>"></td>
-            <td><input type="text" size="15" name="dest_zone" value="<?=$dest_zone?>"></td>
-            <td><input type="text" size="7" name="dest_x" value="<?=$dest_x?>"></td>
-            <td><input type="text" size="7" name="dest_y" value="<?=$dest_y?>"></td>
-            <td><input type="text" size="7" name="dest_z" value="<?=$dest_z?>"></td>
-            <td><input type="text" size="7" name="dest_heading" value="<?=$dest_heading?>"></td>
-            <td><input type="text" size="7" name="keyitem" value="<?=$keyitem?>"></td>
-            <td><input type="text" size="7" name="altkeyitem" value="<?=$altkeyitem?>"></td>
-          </tr>
-          <tr>
-            <th>size</th>
-            <th>triggerdoor</th>
-            <th>triggertype</th>
-            <th>param</th>
-            <th>doorisopen</th>
-            <th>invert</th>
-            <th>incline</th>
-            <th>close_time</th>
-         </tr>
-          <tr>
-            <td><input type="text" size="7" name="size" value="<?=$size?>"></td>
-            <td><input type="text" size="7" name="triggerdoor" value="<?=$triggerdoor?>"></td>
-            <td><input type="text" size="7" name="triggertype" value="<?=$triggertype?>"></td>
-            <td><input type="text" size="7" name="door_param" value="<?=$door_param?>"></td>
-            <td><input type="text" size="7" name="doorisopen" value="<?=$doorisopen?>"></td>
-            <td><input type="text" size="7" name="invert_state" value="<?=$invert_state?>"></td>
-            <td><input type="text" size="7" name="incline" value="<?=$incline?>"></td>
-            <td><input type="text" size="7" name="close_time" value="<?=$close_time?>"></td>
-         </tr>
-          <tr>
-            <th>nokeyring</th>
-            <th>islift</th>
-            <th>can_open</th>
-         </tr>
-          <tr>
-            <td><select class="left" name="nokeyring">
-<?foreach($yesno as $k => $v):?>
-              <option value="<?=$k?>"<? echo ($k == $nokeyring) ? " selected" : ""?>><?=$v?></option>
-<?$x++; endforeach;?>
-           </td> 
-            <td><select class="left" name="islift">
-<?foreach($yesno as $k => $v):?>
-              <option value="<?=$k?>"<? echo ($k == $islift) ? " selected" : ""?>><?=$v?></option>
-<?$x++; endforeach;?>
-           </td> 
-          <td><select class="left" name="can_open">
-<?foreach($yesno as $k => $v):?>
-              <option value="<?=$k?>"<? echo ($k == $can_open) ? " selected" : ""?>><?=$v?></option>
-<?$x++; endforeach;?>
-           </td> 
-         </tr>
-              </table><br><br>
-        <center>
-          <input type="hidden" name="drid" value="<?=$id?>">
-          <input type="submit" value="Submit Changes">
-        </center>
-      </form>
-      </div>
-      </div>
+    <div class="edit_form_header">
+        Edit Door: <?= $id ?>
+    </div>
+    <div class="edit_form_content">
+        <form name="door" method="post"
+              action=index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=37">
+            <div style="padding-bottom:20px;">
+                <fieldset>
+                    <legend>Identity</legend>
+                    <table style="width: 100%; border-spacing: 20px;">
+                        <tr>
+                            <th colspan="2"><label for="name">Door Name</label></th>
+                            <th colspan="2"><label for="doorid">doorid</label></th>
+                            <th colspan="2"><label for="client_version_mask">client version mask</label></th>
+                        </tr>
+                        <tr>
+                            <td colspan="2"><input type="text" size="15" id="name" name="name"
+                                                   value="<?= $name ?? "" ?>"></td>
+                            <td colspan="2"><input type="text" size="7" id="doorid" name="doorid"
+                                                   value="<?= $doorid ?? "" ?>"></td>
+                            <td colspan="2"><input type="text" size="10" id="client_version_mask"
+                                                   name="client_version_mask" value="<?= $client_version_mask ?? "" ?>">
+                            </td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div style="padding-bottom:20px;">
+                <fieldset>
+                    <legend>Location Data</legend>
+                    <table style="width: 100%; border-spacing: 20px;">
+                        <tr>
+                            <th colspan="2"><label for="curr_zone">curr zone (shortname)</label></th>
+                            <th colspan="2"><label for="pos_x">x</label></th>
+                            <th colspan="2"><label for="pos_y">y</label></th>
+                            <th colspan="2"><label for="pos_z">z</label></th>
+                            <th colspan="2"><label for="heading">heading</label></th>
+                        </tr>
+                        <tr>
+                            <td colspan="2" style="padding-top: 5px;"><input type="text" size="15" id="curr_zone"
+                                                                             name="curr_zone" disabled
+                                                                             value="<?= $currzone ?? "" ?>"></td>
+                            <td colspan="2" style="padding-top: 5px"><input type="text" size="7" id="pos_x" name="pos_x"
+                                                                            value="<?= $pos_x ?? "" ?>"></td>
+                            <td colspan="2" style="padding-top: 5px;"><input type="text" size="7" id="pos_y"
+                                                                             name="pos_y" value="<?= $pos_y ?? "" ?>">
+                            </td>
+                            <td colspan="2" style="padding-top: 5px;"><input type="text" size="7" id="pos_z"
+                                                                             name="pos_z" value="<?= $pos_z ?? "" ?>">
+                            </td>
+                            <td colspan="2" style="padding-top: 5px;"><input type="text" size="7" id="heading"
+                                                                             name="heading"
+                                                                             value="<?= $heading ?? "" ?>"></td>
+                        </tr>
+                        <tr>
+                            <th colspan="2"><label for="dest_zone">dest zone (shortname)</label></th>
+                            <th colspan="2"><label for="dest_x">dest x</label></th>
+                            <th colspan="2"><label for="dest_y">dest y</label></th>
+                            <th colspan="2"><label for="dest_z">dest z</label></th>
+                            <th colspan="2"><label for="dest_heading">dest heading</label></th>
+                        </tr>
+                        <tr>
+                            <td colspan="2"><input type="text" size="15" id="dest_zone" name="dest_zone"
+                                                   value="<?= $dest_zone ?? "" ?>"></td>
+                            <td colspan="2"><input type="text" size="7" id="dest_x" name="dest_x"
+                                                   value="<?= $dest_x ?? "" ?>"></td>
+                            <td colspan="2"><input type="text" size="7" id="dest_y" name="dest_y"
+                                                   value="<?= $dest_y ?? "" ?>"></td>
+                            <td colspan="2"><input type="text" size="7" id="dest_z" name="dest_z"
+                                                   value="<?= $dest_z ?? "" ?>"></td>
+                            <td colspan="2"><input type="text" size="7" id="dest_heading" name="dest_heading"
+                                                   value="<?= $dest_heading ?? "" ?>"></td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div style="padding-bottom:20px;">
+                <fieldset>
+                    <legend>Door Characteristics</legend>
+                    <table style="width: 100%; border-spacing: 20px;">
+                        <tr>
+                            <th colspan="2"><label for="opentype">opentype</label></th>
+                            <th colspan="2"><label for="doorisopen">doorisopen</label></th>
+                            <th colspan="2"><label for="can_open">can_open</label></th>
+                            <th colspan="2"><label for="islift">islift</label></th>
+                        </tr>
+                        <tr>
+                            <td colspan="2"><input type="text" size="7" id="opentype" name="opentype"
+                                                   value="<?= $opentype ?? "" ?>"></td>
+                            <td colspan="2"><input type="text" size="7" id="doorisopen" name="doorisopen"
+                                                   value="<?= $doorisopen ?? "" ?>"></td>
+                            <td colspan="2"><select class="left" id="can_open" name="can_open">
+                                    <?php foreach ($yesno as $k => $v): ?>
+                                        <option value="<?= $k ?>"<?php echo (isset($can_open) && $k == $can_open) ? " selected" : "" ?>><?= $v ?></option>
+                                        <?php $x++; endforeach; ?>
+                            </td>
+                            <td colspan="2"><select class="left" id="islift" name="islift">
+                                    <?php foreach ($yesno as $k => $v): ?>
+                                        <option value="<?= $k ?>"<?php echo (isset($islift) && $k == $islift) ? " selected" : "" ?>><?= $v ?></option>
+                                        <?php $x++; endforeach; ?>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th colspan="2"><label for="triggerdoor">triggerdoor</label></th>
+                            <th colspan="2"><label for="triggertype">triggertype</label></th>
+                            <th colspan="2"><label for="door_param">param</label></th>
+                            <th colspan="2"><label for="invert_state">invert</label></th>
+                            <th colspan="2"><label for="incline">incline</label></th>
+                        </tr>
+                        <tr>
+                            <td colspan="2"><input type="text" size="7" id="triggerdoor" name="triggerdoor"
+                                                   value="<?= $triggerdoor ?? "" ?>"></td>
+                            <td colspan="2"><input type="text" size="7" id="triggertype" name="triggertype"
+                                                   value="<?= $triggertype ?? "" ?>"></td>
+                            <td colspan="2"><input type="text" size="7" id="door_param" name="door_param"
+                                                   value="<?= $door_param ?? "" ?>"></td>
+                            <td colspan="2"><input type="text" size="7" id="invert_state" name="invert_state"
+                                                   value="<?= $invert_state ?? "" ?>"></td>
+                            <td colspan="2"><input type="text" size="7" id="incline" name="incline"
+                                                   value="<?= $incline ?? "" ?>"></td>
+                        </tr>
+                        <tr>
+                            <th colspan="2"><label for="close_time">close_time</label></th>
+                            <th colspan="2"><label for="size">size</label></th>
+                        </tr>
+                        <tr>
+                            <td colspan="2"><input type="text" size="7" id="close_time" name="close_time"
+                                                   value="<?= $close_time ?? "" ?>"></td>
+                            <td colspan="2"><input type="text" size="7" id="size" name="size"
+                                                   value="<?= $size ?? "" ?>"></td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div style="padding-bottom:20px;">
+                <fieldset>
+                    <legend>Access Control</legend>
+                    <table style="width: 100%; border-spacing: 20px;">
+                        <tr>
+                            <th colspan="2"><label for="nokeyring">nokeyring</label></th>
+                            <th colspan="2"><label for="lockpick">lockpick</label></th>
+                            <th colspan="2"><label for="keyitem">key item id</label></th>
+                            <th colspan="2"><label for="altkeyitem">alt key item id</label></th>
+                        </tr>
+                        <tr>
+                            <td colspan="2"><select class="left" id="nokeyring" name="nokeyring">
+                                    <?php foreach ($yesno as $k => $v): ?>
+                                        <option value="<?= $k ?>"<?php echo (isset($nokeyring) && $k == $nokeyring) ? " selected" : "" ?>><?= $v ?></option>
+                                        <?php $x++; endforeach; ?>
+                            </td>
+                            <td colspan="2"><input type="text" size="7" id="lockpick" name="lockpick"
+                                                   value="<?= $lockpick ?? "" ?>"></td>
+                            <td colspan="2"><input type="text" size="7" id="keyitem" name="keyitem"
+                                                   value="<?= $keyitem ?? "" ?>">
+                            </td>
+                            <td colspan="2"><input type="text" size="7" id="altkeyitem" name="altkeyitem"
+                                                   value="<?= $altkeyitem ?? "" ?>"></td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div class="center">
+                <input type="hidden" name="drid" value="<?= $id ?>">
+                <input type="submit" value="Submit Changes">
+            </div>
+        </form>
+    </div>
+</div>

--- a/templates/misc/doors.objects.tmpl.php
+++ b/templates/misc/doors.objects.tmpl.php
@@ -1,44 +1,53 @@
-    <div class="table_container" style="width: 450px;">
-      <div class="table_header">
-        <table width="100%" cellpadding="0" cellspacing="0">
-          <tr>
-           <td>Doors</td>
-           <td align="right">
-          <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=35"><img src="images/contents.png" border="0" title="View normal doors"></a>
-          <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=39"><img src="images/add.gif" border="0" title="Add an entry to this zone"></a>
-            </td>
-           </tr>
-         </table>
-      </div>
-      <table class="table_content2" width="100%">
-<?if (isset($doors)):?>
-        <tr>
-          <td align="center" width="10%"><strong>ID</strong></td>
-          <td align="center" width="7%"><strong>Door ID</strong></td>
-          <td align="center" width="25%"><strong>Name</strong></td>
-          <td align="center" width="15%"><strong>X</strong></td>
-          <td align="center" width="15%"><strong>Y</strong></td>
-          <td align="center" width="15%"><strong>Z</strong></td>
-        </tr>
-<?$x=0; foreach($doors as $door=>$v):?>
-        <tr bgcolor="#<? echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA";?>">
-          <td align="center" width="10%"><?=$v['drid']?></td>
-          <td align="center" width="7%"><?=$v['doorid']?></td>
-          <td align="center" width="25%"><?=$v['name']?></td>
-          <td align="center" width="15%"><?=$v['pos_x']?></td>
-          <td align="center" width="15%"><?=$v['pos_y']?></td>
-          <td align="center" width="15%"><?=$v['pos_z']?></td>
-          <td align="right">
-            <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&drid=<?=$v['drid']?>&action=36"><img src="images/edit2.gif" border="0" title="Edit Entry"></a>
-            <a onClick="return confirm('Really Delete Door <?=$v['drid']?>?');" href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&drid=<?=$v['drid']?>&action=38"><img src="images/remove3.gif" border="0" title="Delete this entry"></a>
-          </td>
-        </tr>
-<?$x++; endforeach;?>
-<?endif;?>
-<?if (!isset($doors)):?>
-        <tr>
-          <td align="left" width="100" style="padding: 10px;">No doors</td>
-        </tr>
-<?endif;?>
-      </table>
+<div class="table_container" style="width: 450px;">
+    <div class="table_header">
+        <table style="width: 100%; border-collapse: collapse; border-spacing: 0;">
+            <tr>
+                <td style="padding: 0;">Doors</td>
+                <td style="padding: 0; text-align: right;">
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=35"><img
+                                src="images/contents.png" style="border: 0;" alt="Contents Icon"
+                                title="View normal doors"></a>
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=39"><img
+                                src="images/add.gif" style="border: 0;" alt="Add Icon"
+                                title="Add an entry to this zone"></a>
+                </td>
+            </tr>
+        </table>
     </div>
+    <table class="table_content2" style="width: 100%;">
+        <?php if (isset($doors)): ?>
+            <tr>
+                <td style="text-align: center; width: 10%;"><strong>ID</strong></td>
+                <td style="text-align: center; width: 7%;"><strong>Door ID</strong></td>
+                <td style="text-align: center; width: 25%;"><strong>Name</strong></td>
+                <td style="text-align: center; width: 15%;"><strong>X</strong></td>
+                <td style="text-align: center; width: 15%;"><strong>Y</strong></td>
+                <td style="text-align: center; width: 15%;"><strong>Z</strong></td>
+            </tr>
+            <?php $x = 0;
+            foreach ($doors as $door => $v): ?>
+                <tr style="background-color: #<?php echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA"; ?>">
+                    <td style="text-align: center; width: 10%;"><?= $v['drid'] ?></td>
+                    <td style="text-align: center; width: 7%;"><?= $v['doorid'] ?></td>
+                    <td style="text-align: center; width: 25%;"><?= $v['name'] ?></td>
+                    <td style="text-align: center; width: 15%;"><?= $v['pos_x'] ?></td>
+                    <td style="text-align: center; width: 15%;"><?= $v['pos_y'] ?></td>
+                    <td style="text-align: center; width: 15%;"><?= $v['pos_z'] ?></td>
+                    <td style="text-align: right;">
+                        <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&drid=<?= $v['drid'] ?>&action=36"><img
+                                    src="images/edit2.gif" style="border: 0;" alt="Edit Icon" title="Edit Entry"></a>
+                        <a onClick="return confirm('Really Delete Door <?= $v['drid'] ?>?');"
+                           href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&drid=<?= $v['drid'] ?>&action=38"><img
+                                    src="images/remove3.gif" style="border: 0;" alt="Remove Icon"
+                                    title="Delete this entry"></a>
+                    </td>
+                </tr>
+                <?php $x++; endforeach; ?>
+        <?php endif; ?>
+        <?php if (!isset($doors)): ?>
+            <tr>
+                <td style="text-align: left; width: 100px; padding: 10px;">No doors</td>
+            </tr>
+        <?php endif; ?>
+    </table>
+</div>

--- a/templates/misc/doors.tmpl.php
+++ b/templates/misc/doors.tmpl.php
@@ -1,68 +1,81 @@
-    <div class="table_container" style="width: 750px;">
-      <div class="table_header">
-        <table width="100%" cellpadding="0" cellspacing="0">
-          <tr>
-           <td>Doors</td>
-           <td align="right">
-          <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=47"><img src="images/contents.png" border="0" title="View door objects"></a>
-          <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=39"><img src="images/add.gif" border="0" title="Add an entry to this zone"></a>
-            </td>
-           </tr>
-         </table>
-      </div>
-      <table class="table_content2" width="100%">
-<?if (isset($doors)):?>
-        <tr>
-          <td align="center" width="7%"><strong>ID</strong></td>
-          <td align="center" width="5%"><strong>Door ID</strong></td>
-          <td align="center" width="10%"><strong>Name</strong></td>
-          <td align="center" width="8%"><strong>X</strong></td>
-          <td align="center" width="8%"><strong>Y</strong></td>
-          <td align="center" width="7%"><strong>Z</strong></td>
-          <td align="center" width="3%"><strong>LckPck</strong></td>
-          <td align="center" width="3%"><strong>Key</strong></td>
-          <td align="center" width="3%"><strong>AltKey</strong></td>
-          <td align="center" width="3%"><strong>Type</strong></td>
-          <td align="center" width="7%"><strong>Dest Zone</strong></td>
-          <td align="center" width="7%"><strong>Dest X</strong></td>
-          <td align="center" width="7%"><strong>Dest Y</strong></td>
-          <td align="center" width="7%"><strong>Dest Z</strong></td>
-        </tr>
-<?$x=0; foreach($doors as $door=>$v):?>
-        <tr bgcolor="#<? echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA";?>">
-          <td align="center" width="7%"><?=$v['drid']?></td>
-          <td align="center" width="5%"><?=$v['doorid']?></td>
-          <td align="center" width="10%"><?=$v['name']?></td>
-          <td align="center" width="8%"><?=$v['pos_x']?></td>
-          <td align="center" width="8%"><?=$v['pos_y']?></td>
-          <td align="center" width="7%"><?=$v['pos_z']?></td>
-          <td align="center" width="3%"><?=$v['lockpick']?></td>
-<?if($v['keyitem'] > 1000):?>
-          <td align="center" width="3%"><?=get_item_name($v['keyitem'])?> <span>[<a href="http://lucy.allakhazam.com/item.html?id=<?=$v['keyitem']?>">lucy</a>]</span></td>
-<?else:?>
-		  <td align="center" width="3%"><?=$v['keyitem']?></td>
-<?endif;?>
-<?if($v['altkeyitem'] > 1000):?>
-          <td align="center" width="3%"><?=get_item_name($v['altkeyitem'])?> <span>[<a href="http://lucy.allakhazam.com/item.html?id=<?=$v['altkeyitem']?>">lucy</a>]</span></td>
-<?else:?>
-		  <td align="center" width="3%"><?=$v['altkeyitem']?></td>
-<?endif;?>
-          <td align="center" width="3%"><?=$v['opentype']?></td>
-          <td align="center" width="7%"><?=$v['dest_zone']?></td>
-          <td align="center" width="7%"><?=$v['dest_x']?></td>
-          <td align="center" width="7%"><?=$v['dest_y']?></td>
-          <td align="center" width="7%"><?=$v['dest_z']?></td>
-          <td align="right">
-            <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&drid=<?=$v['drid']?>&action=36"><img src="images/edit2.gif" border="0" title="Edit Entry"></a>
-            <a onClick="return confirm('Really Delete Door <?=$v['drid']?>?');" href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&drid=<?=$v['drid']?>&action=38"><img src="images/remove3.gif" border="0" title="Delete this entry"></a>
-          </td>
-        </tr>
-<?$x++; endforeach;?>
-<?endif;?>
-<?if (!isset($doors)):?>
-        <tr>
-          <td align="left" width="100" style="padding: 10px;">No doors</td>
-        </tr>
-<?endif;?>
-      </table>
+<div class="table_container" style="width: 750px;">
+    <div class="table_header">
+        <table style="width: 100%; border-collapse: collapse; border-spacing: 0;">
+            <tr>
+                <td style="padding: 0;">Doors</td>
+                <td style="padding: 0; text-align: right;">
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=47"><img
+                                src="images/contents.png" style="border: 0;" alt="Contents Icon"
+                                title="View door objects"></a>
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=39"><img
+                                src="images/add.gif" style="border: 0;" alt="Add Icon"
+                                title="Add an entry to this zone"></a>
+                </td>
+            </tr>
+        </table>
     </div>
+    <table class="table_content2" style="width: 100%;">
+        <?php if (isset($doors)): ?>
+            <tr>
+                <td style="text-align: center; width: 7%;"><strong>ID</strong></td>
+                <td style="text-align: center; width: 5%;"><strong>Door ID</strong></td>
+                <td style="text-align: center; width: 10%;"><strong>Name</strong></td>
+                <td style="text-align: center; width: 8%;"><strong>X</strong></td>
+                <td style="text-align: center; width: 8%;"><strong>Y</strong></td>
+                <td style="text-align: center; width: 7%;"><strong>Z</strong></td>
+                <td style="text-align: center; width: 3%;"><strong>LckPck</strong></td>
+                <td style="text-align: center; width: 3%;"><strong>Key</strong></td>
+                <td style="text-align: center; width: 3%;"><strong>AltKey</strong></td>
+                <td style="text-align: center; width: 3%;"><strong>Type</strong></td>
+                <td style="text-align: center; width: 7%;"><strong>Dest Zone</strong></td>
+                <td style="text-align: center; width: 7%;"><strong>Dest X</strong></td>
+                <td style="text-align: center; width: 7%;"><strong>Dest Y</strong></td>
+                <td style="text-align: center; width: 7%;"><strong>Dest Z</strong></td>
+            </tr>
+            <?php $x = 0;
+            foreach ($doors as $door => $v): ?>
+                <tr style="background-color: #<?php echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA"; ?>">
+                    <td style="text-align: center; width: 7%;"><?= $v['drid'] ?></td>
+                    <td style="text-align: center; width: 5%;"><?= $v['doorid'] ?></td>
+                    <td style="text-align: center; width: 10%;"><?= $v['name'] ?></td>
+                    <td style="text-align: center; width: 8%;"><?= $v['pos_x'] ?></td>
+                    <td style="text-align: center; width: 8%;"><?= $v['pos_y'] ?></td>
+                    <td style="text-align: center; width: 7%;"><?= $v['pos_z'] ?></td>
+                    <td style="text-align: center; width: 3%;"><?= $v['lockpick'] ?></td>
+                    <?php if ($v['keyitem'] > 1000): ?>
+                        <td style="text-align: center; width: 3%;"><?= get_item_name($v['keyitem']) ?> <span>[<a
+                                        href="https://lucy.allakhazam.com/item.html?id=<?= $v['keyitem'] ?>">lucy</a>]</span>
+                        </td>
+                    <?php else: ?>
+                        <td style="text-align: center; width: 3%;"><?= $v['keyitem'] ?></td>
+                    <?php endif; ?>
+                    <?php if ($v['altkeyitem'] > 1000): ?>
+                        <td style="text-align: center; width: 3%;"><?= get_item_name($v['altkeyitem']) ?> <span>[<a
+                                        href="https://lucy.allakhazam.com/item.html?id=<?= $v['altkeyitem'] ?>">lucy</a>]</span>
+                        </td>
+                    <?php else: ?>
+                        <td style="text-align: center; width: 3%;"><?= $v['altkeyitem'] ?></td>
+                    <?php endif; ?>
+                    <td style="text-align: center; width: 3%;"><?= $v['opentype'] ?></td>
+                    <td style="text-align: center; width: 7%;"><?= $v['dest_zone'] ?></td>
+                    <td style="text-align: center; width: 7%;"><?= $v['dest_x'] ?></td>
+                    <td style="text-align: center; width: 7%;"><?= $v['dest_y'] ?></td>
+                    <td style="text-align: center; width: 7%;"><?= $v['dest_z'] ?></td>
+                    <td style="text-align: right;">
+                        <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&drid=<?= $v['drid'] ?>&action=36"><img
+                                    src="images/edit2.gif" style="border: 0;" alt="Edit Icon" title="Edit Entry"></a>
+                        <a onClick="return confirm('Really Delete Door <?= $v['drid'] ?>?');"
+                           href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&drid=<?= $v['drid'] ?>&action=38"><img
+                                    src="images/remove3.gif" style="border: 0;" alt="Remove Icon"
+                                    title="Delete this entry"></a>
+                    </td>
+                </tr>
+                <?php $x++; endforeach; ?>
+        <?php endif; ?>
+        <?php if (!isset($doors)): ?>
+            <tr>
+                <td style="text-align: left; width: 100px; padding: 10px;">No doors</td>
+            </tr>
+        <?php endif; ?>
+    </table>
+</div>

--- a/templates/misc/fishing.add.tmpl.php
+++ b/templates/misc/fishing.add.tmpl.php
@@ -1,28 +1,28 @@
-      <center>
-        <iframe id='searchframe' src='templates/iframes/itemsearch.php'></iframe>
-        <input id="button" type="button" value='Hide Item Search' onclick='hideSearch();' style='display:none; margin-bottom: 20px;'>
-      </center>
+<div class="center">
+    <iframe id='searchframe' src='templates/iframes/itemsearch.php'></iframe>
+    <input id="button" type="button" value='Hide Item Search' onclick='hideSearch();'
+           style='display:none; margin-bottom: 20px;'>
+</div>
 
-      <form method="post" action="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=6">
-      <div class="edit_form" style="width: 200px;">
+<form method="post" action="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=6">
+    <div class="edit_form" style="width: 200px;">
         <div class="edit_form_header">
-          Add Fishing Entry
+            Add Fishing Entry
         </div>
         <div class="edit_form_content">
-            <strong>Item ID</strong> (<a href="javascript:showSearch();">search</a>)<br>
-            <input class="indented" id="id" type="text" name="fiid" size="7" value=""><br><br>
-            <strong>ID</strong><br>
-            <input class="indented" id="id" type="text" name="fsid" size="7" value="<?=$suggestfsid?>"><br><br>
-            <strong>Zone</strong><br>
-            <input class="indented" id="id" type="text" name="zoneid" size="7" value="<?=$zid?>"><br><br>
-            <strong>Skill Level</strong><br>
-            <input class="indented" id="id" type="text" name="skill_level" size="7" value="0"><br><br>
-            <strong>Chance</strong><br>
-            <input class="indented" id="id" type="text" name="chance" size="7" value="0">%<br><br>
+            <strong><label for="fiid">Item ID</label></strong> (<a href="javascript:showSearch();">search</a>)<br>
+            <input class="indented" id="fiid" type="text" name="fiid" size="7" value=""><br><br>
+            <strong><label for="fsid">ID</label></strong><br>
+            <input class="indented" id="fsid" type="text" name="fsid" size="7"
+                   value="<?= $suggestfsid ?? "" ?>"><br><br>
+            <strong><label for="zoneid">Zone</label></strong><br>
+            <input class="indented" id="zoneid" type="text" name="zoneid" size="7" value="<?= $zid ?? "" ?>"><br><br>
+            <strong><label for="skill_level">Skill Level</label></strong><br>
+            <input class="indented" id="skill_level" type="text" name="skill_level" size="7" value="0"><br><br>
+            <strong><label for="chance">Chance</label></strong><br>
+            <input class="indented" id="chance" type="text" name="chance" size="7" value="0">%<br><br>
 
-        <center>
-          <input type="submit" value="Submit Changes">
-        </center>
-      </form>
-      </div>
-      </div>
+            <div class="center">
+                <input type="submit" value="Submit Changes">
+            </div>
+</form>

--- a/templates/misc/fishing.edit.tmpl.php
+++ b/templates/misc/fishing.edit.tmpl.php
@@ -1,27 +1,28 @@
-      <center>
-        <iframe id='searchframe' src='templates/iframes/itemsearch.php'></iframe>
-        <input id="button" type="button" value='Hide Item Search' onclick='hideSearch();' style='display:none; margin-bottom: 20px;'>
-      </center>
+<div class="center">
+    <iframe id='searchframe' src='templates/iframes/itemsearch.php'></iframe>
+    <input id="button" type="button" value='Hide Item Search' onclick='hideSearch();'
+           style='display:none; margin-bottom: 20px;'>
+</div>
 
-        <form name="fishing" method="post" action=index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=3">
-         <div class="edit_form" style="width: 200px;">
+<form name="fishing" method="post"
+      action=index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=3">
+    <div class="edit_form" style="width: 200px;">
         <div class="edit_form_header">
-          Edit Fishing Entry <?=$fsid?>
+            Edit Fishing Entry <?= $fsid ?? "" ?>
         </div>
-         <div class="edit_form_content">
-            <strong>Item ID</strong> (<a href="javascript:showSearch();">search</a>)<br>
-            <input class="indented" id="id" type="text" name="fiid" size="7" value="<?=$fiid?>"><br><br>
-            <strong>Zone</strong><br>
-            <input class="indented" id="id" type="text" name="zoneid" size="7" value="<?=$zoneid?>"><br><br>
-            <strong>Skill Level</strong><br>
-            <input class="indented" id="id" type="text" name="skill_level" size="7" value="<?=$skill_level?>"><br><br>
-            <strong>Chance</strong><br>
-            <input class="indented" id="id" type="text" name="chance" size="7" value="<?=$chance?>">%<br><br>
+        <div class="edit_form_content">
+            <strong><label for="fiid">Item ID</label></strong> (<a href="javascript:showSearch();">search</a>)<br>
+            <input class="indented" id="fiid" type="text" name="fiid" size="7" value="<?= $fiid ?? "" ?>"><br><br>
+            <strong><label for="zoneid">Zone</label></strong><br>
+            <input class="indented" id="zoneid" type="text" name="zoneid" size="7" value="<?= $zoneid ?>"><br><br>
+            <strong><label for="skill_level">Skill Level</label></strong><br>
+            <input class="indented" id="skill_level" type="text" name="skill_level" size="7"
+                   value="<?= $skill_level ?? "" ?>"><br><br>
+            <strong><label for="chance">Chance</label></strong><br>
+            <input class="indented" id="chance" type="text" name="chance" size="7" value="<?= $chance ?? "" ?>">%<br><br>
 
-        <center>
-          <input type="hidden" name="fsid" value="<?=$fsid?>">
-          <input type="submit" value="Submit Changes">
-        </center>
-      </form>
-      </div>
-      </div>
+            <div class="center">
+                <input type="hidden" name="fsid" value="<?= $fsid ?? "" ?>">
+                <input type="submit" value="Submit Changes">
+            </div>
+</form>

--- a/templates/misc/fishing.tmpl.php
+++ b/templates/misc/fishing.tmpl.php
@@ -1,40 +1,47 @@
-      <div class="table_container" style="width: 700px;">
-      <div class="table_header">
-        <table width="100%" cellpadding="0" cellspacing="0">
-          <tr>
-           <td>Fishing</td>
-           <td align="right">    
-          <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=5"><img src="images/add.gif" border="0" title="Add an entry to this zone"></a>
-            </td>
-           </tr>        
-         </table>
-      </div>
-
-       <table class="table_content2" width="100%">
-<? if (isset($fishing)):?>
-         <tr>
-          <td align="center" width="5%"><strong>ID</strong></td>
-          <td align="center" width="12%"><strong>Item</strong></td>
-          <td align="center" width="8%"><strong>Skill Level</strong></td>
-          <td align="center" width="8%"><strong>Chance</strong></td>
-          <th width="5%"></th>
-         </tr>
-<?$x=0; foreach($fishing as $fishing=>$v):?>
-        <tr bgcolor="#<? echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA";?>">
-          <td align="center" width="5%"><?=$v['fsid']?></td>
-          <td align="center" width="12%"><a href="index.php?editor=items&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&id=<?=$v['fiid']?>&action=2"><?=$v['name']?></a> <span>[<a href="http://lucy.allakhazam.com/item.html?id=<?=$v['fiid']?>">lucy</a>]</span></td>
-          <td align="center" width="8%"><?=$v['skill_level']?></td>
-          <td align="center" width="8%"><?=$v['chance']?>%</td>
-          <td align="right">      
-            <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&fsid=<?=$v['fsid']?>&action=2"><img src="images/edit2.gif" border="0" title="Edit Entry"></a>          
-            <a onClick="return confirm('Really Delete Entry <?=$v['fsid']?>?');" href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&fsid=<?=$v['fsid']?>&action=4"><img src="images/remove3.gif" border="0" title="Delete this entry"></a>
-          </td>
-        </tr>
-        <?$x++; endforeach;?>
+<div class="table_container" style="width: 700px;">
+    <div class="table_header">
+        <table style="width: 100%; border-collapse: collapse; border-spacing: 0;">
+            <tr>
+                <td style="padding: 0;">Fishing</td>
+                <td style="padding: 0; text-align: right;">
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=5"><img
+                                src="images/add.gif" style="border: 0;" alt="Add Icon" title="Add an entry to this zone"></a>
+                </td>
+            </tr>
         </table>
-        <?endif;?>
-<? if (!isset($fishing)):?>
+    </div>
+
+    <table class="table_content2" style="width: 100%;">
+        <?php if (isset($fishing)): ?>
         <tr>
-          <td align="left" width="100" style="padding: 10px;">No fishing data</td>
+            <td style="text-align: center; width: 5%"><strong>ID</strong></td>
+            <td style="text-align: center; width: 12%"><strong>Item</strong></td>
+            <td style="text-align: center; width: 8%"><strong>Skill Level</strong></td>
+            <td style="text-align: center; width: 8%"><strong>Chance</strong></td>
+            <th style="width: 5%;"></th>
         </tr>
-<?endif;?>
+        <?php $x = 0;
+        foreach ($fishing as $key => $v): ?>
+            <tr style="background-color: #<?php echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA"; ?>">
+                <td style="text-align: center; width: 5%"><?= $v['fsid'] ?></td>
+                <td style="text-align: center; width: 12%"><a
+                            href="index.php?editor=items&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&id=<?= $v['fiid'] ?>&action=2"><?= $v['name'] ?></a>
+                    <span>[<a href="https://lucy.allakhazam.com/item.html?id=<?= $v['fiid'] ?>">lucy</a>]</span></td>
+                <td style="text-align: center; width: 8%"><?= $v['skill_level'] ?></td>
+                <td style="text-align: center; width: 8%"><?= $v['chance'] ?>%</td>
+                <td style="text-align: right;">
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&fsid=<?= $v['fsid'] ?>&action=2"><img
+                                src="images/edit2.gif" style="border: 0;" alt="Edit Icon" title="Edit Entry"></a>
+                    <a onClick="return confirm('Really Delete Entry <?= $v['fsid'] ?>?');"
+                       href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&fsid=<?= $v['fsid'] ?>&action=4"><img
+                                src="images/remove3.gif" style="border: 0;" alt="Remove Icon" title="Delete this entry"></a>
+                </td>
+            </tr>
+            <?php $x++; endforeach; ?>
+    </table>
+    <?php endif; ?>
+    <?php if (!isset($fishing)): ?>
+    <tr>
+        <td style="text-align: left; width: 100px; padding: 10px;">No fishing data</td>
+    </tr>
+<?php endif; ?>

--- a/templates/misc/fishing.view.tmpl.php
+++ b/templates/misc/fishing.view.tmpl.php
@@ -1,38 +1,43 @@
-      <div class="table_container" style="width: 600px;">
-      <div class="table_header">
-        <table width="100%" cellpadding="0" cellspacing="0">
-          <tr>
-           <td>Fishing</td>
-           <td align="right">    
-          <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=5"><img src="images/add.gif" border="0" title="Add an entry to this zone"></a>
-            </td>
-           </tr>        
-         </table>
-      </div>
-
-       <table class="table_content2" width="100%">
-         <tr>
-          <td align="center" width="5%"><strong>ID</strong></td>
-          <td align="center" width="12%"><strong>Item</strong></td>
-          <td align="center" width="12%"><strong>Zone</strong></td>
-          <td align="center" width="8%"><strong>Skill Level</strong></td>
-          <td align="center" width="8%"><strong>Chance</strong></td>
-          <th width="5%"></th>
-         </tr>
-        <tr bgcolor="#<? echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA";?>">
-          <td align="center" width="5%"><?=$fsid?></td>
-          <td align="center" width="12%"><?=get_item_name($fiid)?> <span>[<a href="http://lucy.allakhazam.com/item.html?id=<?=$fiid?>">lucy</a>]</span></td>
-<?if($zoneid == 0):?>          
-          <td align="center" width="12%">All</td>
-<?endif;?>
-<?if($zoneid != 0):?>          
-          <td align="center" width="12%"><?=getZoneName($zoneid)?></td>
-<?endif;?>
-          <td align="center" width="8%"><?=$skill_level?></td>
-          <td align="center" width="8%"><?=$chance?>%</td>
-          <td align="right">      
-            <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&fsid=<?=$fsid?>&action=2"><img src="images/edit2.gif" border="0" title="Edit Entry"></a>          
-            <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&fsid=<?=$fsid?>&action=4"><img src="images/remove3.gif" border="0" title="Delete this entry"></a>
-          </td>
-        </tr>
+<div class="table_container" style="width: 600px;">
+    <div class="table_header">
+        <table style="width: 100%; border-collapse: collapse; border-spacing: 0;">
+            <tr>
+                <td style="padding: 0;">Fishing</td>
+                <td style="padding: 0; text-align: right;">
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=5"><img
+                                src="images/add.gif" style="border: 0;" alt="Add Icon"
+                                title="Add an entry to this zone"></a>
+                </td>
+            </tr>
         </table>
+    </div>
+
+    <table class="table_content2" style="width: 100%;">
+        <tr>
+            <td style="text-align: center; width: 5%"><strong>ID</strong></td>
+            <td style="text-align: center; width: 12%"><strong>Item</strong></td>
+            <td style="text-align: center; width: 12%"><strong>Zone</strong></td>
+            <td style="text-align: center; width: 8%"><strong>Skill Level</strong></td>
+            <td style="text-align: center; width: 8%"><strong>Chance</strong></td>
+            <th style="width: 5%;"></th>
+        </tr>
+        <tr style="background-color: #<?php echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA"; ?>">
+            <td style="text-align: center; width: 5%"><?= $fsid ?? "" ?></td>
+            <td style="text-align: center; width: 12%"><?= get_item_name($fiid ?? "") ?> <span>[<a
+                            href="https://lucy.allakhazam.com/item.html?id=<?= $fiid ?? "" ?>">lucy</a>]</span></td>
+            <?php if ($zoneid == 0): ?>
+                <td style="text-align: center; width: 12%">All</td>
+            <?php endif; ?>
+            <?php if ($zoneid != 0): ?>
+                <td style="text-align: center; width: 12%"><?= getZoneName($zoneid) ?></td>
+            <?php endif; ?>
+            <td style="text-align: center; width: 8%"><?= $skill_level ?? "" ?></td>
+            <td style="text-align: center; width: 8%"><?= $chance ?? "" ?>%</td>
+            <td style="text-align: right;">
+                <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&fsid=<?= $fsid ?? "" ?>&action=2"><img
+                            src="images/edit2.gif" style="border: 0;" alt="Edit Icon" title="Edit Entry"></a>
+                <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&fsid=<?= $fsid ?? "" ?>&action=4"><img
+                            src="images/remove3.gif" style="border: 0;" alt="Remove Icon" title="Delete this entry"></a>
+            </td>
+        </tr>
+    </table>

--- a/templates/misc/forage.add.tmpl.php
+++ b/templates/misc/forage.add.tmpl.php
@@ -1,28 +1,28 @@
-      <center>
-        <iframe id='searchframe' src='templates/iframes/itemsearch.php'></iframe>
-        <input id="button" type="button" value='Hide Item Search' onclick='hideSearch();' style='display:none; margin-bottom: 20px;'>
-      </center>
+<div class="center">
+    <iframe id='searchframe' src='templates/iframes/itemsearch.php'></iframe>
+    <input id="button" type="button" value='Hide Item Search' onclick='hideSearch();'
+           style='display:none; margin-bottom: 20px;'>
+</div>
 
-      <form method="post" action="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=12">
-      <div class="edit_form" style="width: 200px;">
+<form method="post" action="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=12">
+    <div class="edit_form" style="width: 200px;">
         <div class="edit_form_header">
-          Add Forage Entry
+            Add Forage Entry
         </div>
         <div class="edit_form_content">
-            <strong>Item ID</strong> (<a href="javascript:showSearch();">search</a>)<br>
-            <input class="indented" id="id" type="text" name="fgiid" size="7" value=""><br><br>
-            <strong>ID</strong><br>
-            <input class="indented" id="id" type="text" name="fgid" size="7" value="<?=$suggestfgid?>"><br><br>
-            <strong>Zone</strong><br>
-            <input class="indented" id="id" type="text" name="zoneid" size="7" value="<?=$zid?>"><br><br>
-            <strong>Level</strong><br>
-            <input class="indented" id="id" type="text" name="level" size="7" value="0"><br><br>
-            <strong>Chance</strong><br>
-            <input class="indented" id="id" type="text" name="chance" size="7" value="0">%<br><br>
+            <strong><label for="fgiid">Item ID</label></strong> (<a href="javascript:showSearch();">search</a>)<br>
+            <input class="indented" id="fgiid" type="text" name="fgiid" size="7" value=""><br><br>
+            <strong><label for="fgid">ID</label></strong><br>
+            <input class="indented" id="fgid" type="text" name="fgid" size="7"
+                   value="<?= $suggestfgid ?? "" ?>"><br><br>
+            <strong><label for="zoneid">Zone</label></strong><br>
+            <input class="indented" id="zoneid" type="text" name="zoneid" size="7" value="<?= $zid ?? "" ?>"><br><br>
+            <strong><label for="level">Level</label></strong><br>
+            <input class="indented" id="level" type="text" name="level" size="7" value="0"><br><br>
+            <strong><label for="chance">Chance</label></strong><br>
+            <input class="indented" id="chance" type="text" name="chance" size="7" value="0">%<br><br>
 
-        <center>
-          <input type="submit" value="Submit Changes">
-        </center>
-      </form>
-      </div>
-      </div>
+            <div class="center">
+                <input type="submit" value="Submit Changes">
+            </div>
+</form>

--- a/templates/misc/forage.edit.tmpl.php
+++ b/templates/misc/forage.edit.tmpl.php
@@ -1,27 +1,28 @@
-      <center>
-        <iframe id='searchframe' src='templates/iframes/itemsearch.php'></iframe>
-        <input id="button" type="button" value='Hide Item Search' onclick='hideSearch();' style='display:none; margin-bottom: 20px;'>
-      </center>
+<div class="center">
+    <iframe id='searchframe' src='templates/iframes/itemsearch.php'></iframe>
+    <input id="button" type="button" value='Hide Item Search' onclick='hideSearch();'
+           style='display:none; margin-bottom: 20px;'>
+</div>
 
-        <form name="forage" method="post" action=index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=9">
-         <div class="edit_form" style="width: 200px;">
+<form name="forage" method="post"
+      action=index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=9">
+    <div class="edit_form" style="width: 200px;">
         <div class="edit_form_header">
-          Edit Forage Entry <?=$fgid?>
+            Edit Forage Entry <?= $fgid ?? "" ?>
         </div>
-         <div class="edit_form_content">
-            <strong>Item ID</strong> (<a href="javascript:showSearch();">search</a>)<br>
-            <input class="indented" id="id" type="text" name="fgiid" size="7" value="<?=$fgiid?>"><br><br>
-            <strong>Zone</strong><br>
-            <input class="indented" id="id" type="text" name="zoneid" size="7" value="<?=$zoneid?>"><br><br>
-            <strong>Level</strong><br>
-            <input class="indented" id="id" type="text" name="level" size="7" value="<?=$level?>"><br><br>
-            <strong>Chance</strong><br>
-            <input class="indented" id="id" type="text" name="chance" size="7" value="<?=$chance?>">%<br><br>
+        <div class="edit_form_content">
+            <strong><label for="fgiid">Item ID</label></strong> (<a href="javascript:showSearch();">search</a>)<br>
+            <input class="indented" id="fgiid" type="text" name="fgiid" size="7" value="<?= $fgiid ?? "" ?>"><br><br>
+            <strong><label for="zoneid">Zone</label></strong><br>
+            <input class="indented" id="zoneid" type="text" name="zoneid" size="7" value="<?= $zoneid ?? "" ?>"><br><br>
+            <strong><label for="level">Level</label></strong><br>
+            <input class="indented" id="level" type="text" name="level" size="7" value="<?= $level ?? "" ?>"><br><br>
+            <strong><label for="chance">Chance</label></strong><br>
+            <input class="indented" id="chance" type="text" name="chance" size="7"
+                   value="<?= $chance ?? "" ?>">%<br><br>
 
-        <center>
-          <input type="hidden" name="fgid" value="<?=$fgid?>">
-          <input type="submit" value="Submit Changes">
-        </center>
-      </form>
-      </div>
-      </div>
+            <div class="fgid">
+                <input type="hidden" name="fgid" value="<?= $fgid ?? "" ?>">
+                <input type="submit" value="Submit Changes">
+            </div>
+</form>

--- a/templates/misc/forage.tmpl.php
+++ b/templates/misc/forage.tmpl.php
@@ -1,40 +1,48 @@
-      <div class="table_container" style="width: 500px;">
-      <div class="table_header">
-        <table width="100%" cellpadding="0" cellspacing="0">
-          <tr>
-           <td>Forage</td>
-           <td align="right">    
-          <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=11"><img src="images/add.gif" border="0" title="Add an entry to this zone"></a>
-            </td>
-           </tr>        
-         </table>
-      </div>
-
-       <table class="table_content2" width="100%">
-<? if (isset($forage)):?>
-         <tr>
-          <td align="center" width="5%"><strong>ID</strong></td>
-          <td align="center" width="20%"><strong>Item</strong></td>
-          <td align="center" width="15%"><strong>Level</strong></td>
-          <td align="center" width="15%"><strong>Chance</strong></td>
-          <th width="5%"></th>
-         </tr>
-<?$x=0; foreach($forage as $forage=>$v):?>
-        <tr bgcolor="#<? echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA";?>">
-          <td align="center" width="5%"><?=$v['fgid']?></td>
-          <td align="center" width="20%"><a href="index.php?editor=items&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&id=<?=$v['fgiid']?>&action=2"><?=$v['name']?></a> <span>[<a href="http://lucy.allakhazam.com/item.html?id=<?=$v['fgiid']?>">lucy</a>]</span></td>
-          <td align="center" width="15%"><?=$v['level']?></td>
-          <td align="center" width="15%"><?=$v['chance']?>%</td>  
-          <td align="right">      
-            <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&fgid=<?=$v['fgid']?>&action=8"><img src="images/edit2.gif" border="0" title="Edit Entry"></a>          
-            <a onClick="return confirm('Really Delete Entry <?=$v['fgid']?>?');" href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&fgid=<?=$v['fgid']?>&action=10"><img src="images/remove3.gif" border="0" title="Delete this entry"></a>
-          </td>
-        </tr>
-        <?$x++; endforeach;?>
+<div class="table_container" style="width: 500px;">
+    <div class="table_header">
+        <table style="width: 100%; border-collapse: collapse: border-spacing: 0;">
+            <tr>
+                <td style="padding: 0;">Forage</td>
+                <td style="padding: 0; text-align: right;">
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=11"><img
+                                src="images/add.gif" style="border: 0;" alt="Add Icon"
+                                title="Add an entry to this zone"></a>
+                </td>
+            </tr>
         </table>
-        <?endif;?>
-<? if (!isset($forage)):?>
+    </div>
+
+    <table class="table_content2" style="width: 100%;">
+        <?php if (isset($forage)): ?>
         <tr>
-          <td align="left" width="100" style="padding: 10px;">No forage data</td>
+            <td style="text-align: center; width: 5%"><strong>ID</strong></td>
+            <td style="text-align: center; width: 20%"><strong>Item</strong></td>
+            <td style="text-align: center; width: 15%"><strong>Level</strong></td>
+            <td style="text-align: center; width: 15%"><strong>Chance</strong></td>
+            <th style="width: 5%;"></th>
         </tr>
-<?endif;?>
+        <?php $x = 0;
+        foreach ($forage as $key => $v): ?>
+            <tr style="background-color: #<?php echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA"; ?>">
+                <td style="text-align: center; width: 5%"><?= $v['fgid'] ?></td>
+                <td style="text-align: center; width: 20%"><a
+                            href="index.php?editor=items&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&id=<?= $v['fgiid'] ?>&action=2"><?= $v['name'] ?></a>
+                    <span>[<a href="https://lucy.allakhazam.com/item.html?id=<?= $v['fgiid'] ?>">lucy</a>]</span></td>
+                <td style="text-align: center; width: 15%"><?= $v['level'] ?></td>
+                <td style="text-align: center; width: 15%"><?= $v['chance'] ?>%</td>
+                <td style="text-align: right;">
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&fgid=<?= $v['fgid'] ?>&action=8"><img
+                                src="images/edit2.gif" style="border: 0;" alt="Edit Icon" title="Edit Entry"></a>
+                    <a onClick="return confirm('Really Delete Entry <?= $v['fgid'] ?>?');"
+                       href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&fgid=<?= $v['fgid'] ?>&action=10"><img
+                                src="images/remove3.gif" style="border: 0;" alt="Remove Icon" title="Delete this entry"></a>
+                </td>
+            </tr>
+            <?php $x++; endforeach; ?>
+    </table>
+    <?php endif; ?>
+    <?php if (!isset($forage)): ?>
+    <tr>
+        <td style="text-align: left; width: 100px; padding: 10px;">No forage data</td>
+    </tr>
+<?php endif; ?>

--- a/templates/misc/forage.view.tmpl.php
+++ b/templates/misc/forage.view.tmpl.php
@@ -1,38 +1,43 @@
-      <div class="table_container" style="width: 400px;">
-      <div class="table_header">
-        <table width="100%" cellpadding="0" cellspacing="0">
-          <tr>
-           <td>Forage</td>
-           <td align="right">    
-          <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=11"><img src="images/add.gif" border="0" title="Add an entry to this zone"></a>
-            </td>
-           </tr>        
-         </table>
-      </div>
-
-       <table class="table_content2" width="100%">
-         <tr>
-          <td align="center" width="5%"><strong>ID</strong></td>
-          <td align="center" width="10%"><strong>Zone</strong></td>
-          <td align="center" width="20%"><strong>Item</strong></td>
-          <td align="center" width="5%"><strong>Level</strong></td>
-          <td align="center" width="5%"><strong>Chance</strong></td>
-          <th width="5%"></th>
-         </tr>
-        <tr bgcolor="#<? echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA";?>">
-          <td align="center" width="5%"><?=$fgid?></td>
-<?if($zoneid == 0):?>          
-          <td align="center" width="10%">All</td>
-<?endif;?>
-<?if($zoneid != 0):?> 
-          <td align="center" width="10%"><?=getZoneName($zoneid)?></td>
-<?endif;?>
-          <td align="center" width="20%"><?=get_item_name($fgiid)?> <span>[<a href="http://lucy.allakhazam.com/item.html?id=<?=$fgiid?>">lucy</a>]</span></td>
-          <td align="center" width="5%"><?=$level?></td>
-          <td align="center" width="5%"><?=$chance?>%</td>  
-          <td align="right">      
-            <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&fgid=<?=$fgid?>&action=8"><img src="images/edit2.gif" border="0" title="Edit Entry"></a>          
-            <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&fgid=<?=$fgid?>&action=10"><img src="images/remove3.gif" border="0" title="Delete this entry"></a>
-          </td>
-        </tr>
+<div class="table_container" style="width: 400px;">
+    <div class="table_header">
+        <table style="width: 100%; border-collapse: collapse; border-spacing: 0;">
+            <tr>
+                <td style="padding: 0;">Forage</td>
+                <td style="padding: 0; text-align: right;">
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=11"><img
+                                src="images/add.gif" style="border: 0;" alt="Add Icon"
+                                title="Add an entry to this zone"></a>
+                </td>
+            </tr>
         </table>
+    </div>
+
+    <table class="table_content2" style="width: 100%;">
+        <tr>
+            <td style="text-align: center; width: 5%"><strong>ID</strong></td>
+            <td style="text-align: center; width: 10%"><strong>Zone</strong></td>
+            <td style="text-align: center; width: 20%"><strong>Item</strong></td>
+            <td style="text-align: center; width: 5%"><strong>Level</strong></td>
+            <td style="text-align: center; width: 5%"><strong>Chance</strong></td>
+            <th style="width: 5%;"></th>
+        </tr>
+        <tr style="background-color: #<?php echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA"; ?>">
+            <td style="text-align: center; width: 5%"><?= $fgid ?? "" ?></td>
+            <?php if ($zoneid == 0): ?>
+                <td style="text-align: center; width: 10%">All</td>
+            <?php endif; ?>
+            <?php if ($zoneid != 0): ?>
+                <td style="text-align: center; width: 10%"><?= getZoneName($zoneid) ?></td>
+            <?php endif; ?>
+            <td style="text-align: center; width: 20%"><?= get_item_name($fgiid ?? "") ?> <span>[<a
+                            href="https://lucy.allakhazam.com/item.html?id=<?= $fgiid ?? "" ?>">lucy</a>]</span></td>
+            <td style="text-align: center; width: 5%"><?= $level ?></td>
+            <td style="text-align: center; width: 5%"><?= $chance ?? "" ?>%</td>
+            <td style="text-align: right;">
+                <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&fgid=<?= $fgid ?? "" ?>&action=8"><img
+                            src="images/edit2.gif" style="border: 0;" alt="Edit Icon" title="Edit Entry"></a>
+                <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&fgid=<?= $fgid ?? "" ?>&action=10"><img
+                            src="images/remove3.gif" style="border: 0;" alt="Remove Icon" title="Delete this entry"></a>
+            </td>
+        </tr>
+    </table>

--- a/templates/misc/groundspawn.add.tmpl.php
+++ b/templates/misc/groundspawn.add.tmpl.php
@@ -1,44 +1,44 @@
-      <center>
-        <iframe id='searchframe' src='templates/iframes/itemsearch.php'></iframe>
-        <input id="button" type="button" value='Hide Item Search' onclick='hideSearch();' style='display:none; margin-bottom: 20px;'>
-      </center>
+<div class="center">
+    <iframe id='searchframe' src='templates/iframes/itemsearch.php'></iframe>
+    <input id="button" type="button" value='Hide Item Search' onclick='hideSearch();'
+           style='display:none; margin-bottom: 20px;'>
+</div>
 
-      <form method="post" action="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=18">
-      <div class="edit_form" style="width: 200px;">
+<form method="post" action="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=18">
+    <div class="edit_form" style="width: 200px;">
         <div class="edit_form_header">
-          Add Ground Spawn
+            Add Ground Spawn
         </div>
         <div class="edit_form_content">
-            <strong>Item ID</strong> (<a href="javascript:showSearch();">search</a>)<br>
-            <input class="indented" id="id" type="text" name="giid" size="7" value=""><br><br>
-            <strong>ID</strong><br>
-            <input class="indented" id="id" type="text" name="gsid" size="7" value="<?=$suggestgsid?>"><br><br>
-            <strong>Zone</strong><br>
-            <input class="indented" id="id" type="text" name="zoneid" size="7" value="<?=$zid?>"><br><br>
-            <strong>Max X</strong><br>
-            <input class="indented" id="id" type="text" name="max_x" size="7" value="0"><br><br>
-            <strong>Max Y</strong><br>
-            <input class="indented" id="id" type="text" name="max_y" size="7" value="0"><br><br>
-            <strong>Max Z</strong><br>
-            <input class="indented" id="id" type="text" name="max_z" size="7" value="0"><br><br>
-            <strong>Min X</strong><br>
-            <input class="indented" id="id" type="text" name="min_x" size="7" value="0"><br><br>
-            <strong>Min Y</strong><br>
-            <input class="indented" id="id" type="text" name="min_y" size="7" value="0"><br><br>
-            <strong>Heading</strong><br>
-            <input class="indented" id="id" type="text" name="heading" size="7" value="0"><br><br>
-            <strong>Max</strong><br>
-            <input class="indented" id="id" type="text" name="max_allowed" size="7" value="1"><br><br>
-            <strong>Respawn</strong><br>
-            <input class="indented" id="id" type="text" name="respawn_timer" size="7" value="300000"><br><br>
-            <strong>Name</strong><br>
-            <input class="indented" id="id" type="text" name="name" size="20" value="IT"><br><br>
-            <strong>Comment</strong><br>
-            <input class="indented" id="id" type="text" name="comment" size="20" value="Default comment"><br><br>
+            <strong><label for="giid">Item ID</label></strong> (<a href="javascript:showSearch();">search</a>)<br>
+            <input class="indented" id="giid" type="text" name="giid" size="7" value=""><br><br>
+            <strong><label for="gsid">ID</label></strong><br>
+            <input class="indented" id="gsid" type="text" name="gsid" size="7"
+                   value="<?= $suggestgsid ?? "" ?>"><br><br>
+            <strong><label for="zoneid">Zone</label></strong><br>
+            <input class="indented" id="zoneid" type="text" name="zoneid" size="7" value="<?= $zid ?? "" ?>"><br><br>
+            <strong><label for="max_x">Max X</label></strong><br>
+            <input class="indented" id="max_x" type="text" name="max_x" size="7" value="0"><br><br>
+            <strong><label for="max_y">Max Y</label></strong><br>
+            <input class="indented" id="max_y" type="text" name="max_y" size="7" value="0"><br><br>
+            <strong><label for="max_z">Max Z</label></strong><br>
+            <input class="indented" id="max_z" type="text" name="max_z" size="7" value="0"><br><br>
+            <strong><label for="min_x">Min X</label></strong><br>
+            <input class="indented" id="min_x" type="text" name="min_x" size="7" value="0"><br><br>
+            <strong><label for="min_y">Min Y</label></strong><br>
+            <input class="indented" id="min_y" type="text" name="min_y" size="7" value="0"><br><br>
+            <strong><label for="heading">Heading</label></strong><br>
+            <input class="indented" id="heading" type="text" name="heading" size="7" value="0"><br><br>
+            <strong><label for="max_allowed">Max</label></strong><br>
+            <input class="indented" id="max_allowed" type="text" name="max_allowed" size="7" value="1"><br><br>
+            <strong><label for="respawn_timer">Respawn</label></strong><br>
+            <input class="indented" id="respawn_timer" type="text" name="respawn_timer" size="7" value="300000"><br><br>
+            <strong><label for="name">Name</label></strong><br>
+            <input class="indented" id="name" type="text" name="name" size="20" value="IT"><br><br>
+            <strong><label for="comment">Comment</label></strong><br>
+            <input class="indented" id="comment" type="text" name="comment" size="20" value="Default comment"><br><br>
 
-        <center>
-          <input type="submit" value="Submit Changes">
-        </center>
-      </form>
-      </div>
-      </div>
+            <div class="center">
+                <input type="submit" value="Submit Changes">
+            </div>
+</form>

--- a/templates/misc/groundspawn.edit.tmpl.php
+++ b/templates/misc/groundspawn.edit.tmpl.php
@@ -1,43 +1,46 @@
-      <center>
-        <iframe id='searchframe' src='templates/iframes/itemsearch.php'></iframe>
-        <input id="button" type="button" value='Hide Item Search' onclick='hideSearch();' style='display:none; margin-bottom: 20px;'>
-      </center>
+<div class="center">
+    <iframe id='searchframe' src='templates/iframes/itemsearch.php'></iframe>
+    <input id="button" type="button" value='Hide Item Search' onclick='hideSearch();'
+           style='display:none; margin-bottom: 20px;'>
+</div>
 
-        <form name="gspawn" method="post" action=index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=15">
-         <div class="edit_form" style="width: 200px;">
+<form name="gspawn" method="post"
+      action=index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=15">
+    <div class="edit_form" style="width: 200px;">
         <div class="edit_form_header">
-          Edit Ground Spawn <?=$gsid?>
+            Edit Ground Spawn <?= $gsid ?? "" ?>
         </div>
-         <div class="edit_form_content">
-            <strong>Item ID</strong> (<a href="javascript:showSearch();">search</a>)<br>
-            <input class="indented" id="id" type="text" name="giid" size="7" value="<?=$giid?>"><br><br>
-            <strong>Zone</strong><br>
-            <input class="indented" id="id" type="text" name="zoneid" size="7" value="<?=$zoneid?>"><br><br>
-            <strong>Max X</strong><br>
-            <input class="indented" id="id" type="text" name="max_x" size="7" value="<?=$max_x?>"><br><br>
-            <strong>Max Y</strong><br>
-            <input class="indented" id="id" type="text" name="max_y" size="7" value="<?=$max_y?>"><br><br>
-            <strong>Max Z</strong><br>
-            <input class="indented" id="id" type="text" name="max_z" size="7" value="<?=$max_z?>"><br><br>
-            <strong>Min X</strong><br>
-            <input class="indented" id="id" type="text" name="min_x" size="7" value="<?=$min_x?>"><br><br>
-            <strong>Min Y</strong><br>
-            <input class="indented" id="id" type="text" name="min_y" size="7" value="<?=$min_y?>"><br><br>
-            <strong>Heading</strong><br>
-            <input class="indented" id="id" type="text" name="heading" size="7" value="<?=$heading?>"><br><br>
-            <strong>Max</strong><br>
-            <input class="indented" id="id" type="text" name="max_allowed" size="7" value="<?=$max_allowed?>"><br><br>
-            <strong>Respawn</strong><br>
-            <input class="indented" id="id" type="text" name="respawn_timer" size="7" value="<?=$respawn_timer?>"><br><br>
-            <strong>Name</strong><br>
-            <input class="indented" id="id" type="text" name="name" size="20" value="<?=$name?>"><br><br>
-            <strong>Comment</strong><br>
-            <input class="indented" id="id" type="text" name="comment" size="20" value="<?=$comment?>"><br><br>
+        <div class="edit_form_content">
+            <strong><label for="giid">Item ID</label></strong> (<a href="javascript:showSearch();">search</a>)<br>
+            <input class="indented" id="giid" type="text" name="giid" size="7" value="<?= $giid ?? "" ?>"><br><br>
+            <strong><label for="zoneid">Zone</label></strong><br>
+            <input class="indented" id="zoneid" type="text" name="zoneid" size="7" value="<?= $zoneid ?>"><br><br>
+            <strong><label for="max_x">Max X</label></strong><br>
+            <input class="indented" id="max_x" type="text" name="max_x" size="7" value="<?= $max_x ?? "" ?>"><br><br>
+            <strong><label for="max_y">Max Y</label></strong><br>
+            <input class="indented" id="max_y" type="text" name="max_y" size="7" value="<?= $max_y ?? "" ?>"><br><br>
+            <strong><label for="max_z">Max Z</label></strong><br>
+            <input class="indented" id="max_z" type="text" name="max_z" size="7" value="<?= $max_z ?? "" ?>"><br><br>
+            <strong><label for="min_x">Min X</label></strong><br>
+            <input class="indented" id="min_x" type="text" name="min_x" size="7" value="<?= $min_x ?? "" ?>"><br><br>
+            <strong><label for="min_y">Min Y</label></strong><br>
+            <input class="indented" id="min_y" type="text" name="min_y" size="7" value="<?= $min_y ?? "" ?>"><br><br>
+            <strong><label for="heading">Heading</label></strong><br>
+            <input class="indented" id="heading" type="text" name="heading" size="7"
+                   value="<?= $heading ?? "" ?>"><br><br>
+            <strong><label for="max_allowed">Max</label></strong><br>
+            <input class="indented" id="max_allowed" type="text" name="max_allowed" size="7"
+                   value="<?= $max_allowed ?? "" ?>"><br><br>
+            <strong><label for="respawn_timer">Respawn</label></strong><br>
+            <input class="indented" id="respawn_timer" type="text" name="respawn_timer" size="7"
+                   value="<?= $respawn_timer ?? "" ?>"><br><br>
+            <strong><label for="name">Name</label></strong><br>
+            <input class="indented" id="name" type="text" name="name" size="20" value="<?= $name ?? "" ?>"><br><br>
+            <strong><label for="comment">Comment</label></strong><br>
+            <input class="indented" id="comment" type="text" name="comment" size="20" value="<?= $comment ?? "" ?>"><br><br>
 
-        <center>
-          <input type="hidden" name="gsid" value="<?=$gsid?>">
-          <input type="submit" value="Submit Changes">
-        </center>
-      </form>
-      </div>
-      </div>
+            <div class="center">
+                <input type="hidden" name="gsid" value="<?= $gsid ?? "" ?>">
+                <input type="submit" value="Submit Changes">
+            </div>
+</form>

--- a/templates/misc/groundspawn.tmpl.php
+++ b/templates/misc/groundspawn.tmpl.php
@@ -1,50 +1,58 @@
-      <div class="table_container" style="width: 750px;">
-      <div class="table_header">
-        <table width="100%" cellpadding="0" cellspacing="0">
-          <tr>
-           <td>Ground Spawns</td>
-           <td align="right">  
-          <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=17"><img src="images/add.gif" border="0" title="Add an entry to this zone"></a>
-            </td>
-           </tr>        
-         </table>
-      </div>
-
-       <table class="table_content2" width="100%">
-<? if (isset($gspawn)):?>
-         <tr>
-          <td align="center" width="5%"><strong>id</strong></td>
-          <td align="center" width="20%"><strong>item</strong></td>
-          <td align="center" width="5%"><strong>max</strong></td>
-          <td align="center" width="5%"><strong>max x</strong></td>
-          <td align="center" width="5%"><strong>max y</strong></td>
-          <td align="center" width="5%"><strong>max z</strong></td>
-          <td align="center" width="5%"><strong>min x</strong></td>
-          <td align="center" width="5%"><strong>min y</strong></td>
-          <td align="center" width="5%"><strong>respawn</strong></td>
-          <th width="5%"></th>
-         </tr>
-<?$x=0; foreach($gspawn as $gspawn=>$v):?>
-        <tr bgcolor="#<? echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA";?>">
-          <td align="center" width="5%"><?=$v['gsid']?></td>
-          <td align="center" width="20%"><a href="index.php?editor=items&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&id=<?=$v['giid']?>&action=2"><?=$v['iname']?></a> <span>[<a href="http://lucy.allakhazam.com/item.html?id=<?=$v['giid']?>">lucy</a>]</span></td>
-          <td align="center" width="5%"><?=$v['max_allowed']?></td>
-          <td align="center" width="5%"><?=$v['max_x']?></td>
-          <td align="center" width="5%"><?=$v['max_y']?></td>
-          <td align="center" width="5%"><?=$v['max_z']?></td>
-          <td align="center" width="5%"><?=$v['min_x']?></td>
-          <td align="center" width="5%"><?=$v['min_y']?></td>
-          <td align="center" width="5%"><?=$v['respawn_timer']?></td>  
-          <td align="right">      
-            <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&gsid=<?=$v['gsid']?>&action=14"><img src="images/edit2.gif" border="0" title="Edit Entry"></a>          
-            <a onClick="return confirm('Really Delete Entry <?=$v['gsid']?>?');" href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&gsid=<?=$v['gsid']?>&action=16"><img src="images/remove3.gif" border="0" title="Delete this entry"></a>
-          </td>
-        </tr>
-        <?$x++; endforeach;?>
+<div class="table_container" style="width: 750px;">
+    <div class="table_header">
+        <table style="width: 100%; border-collapse: collapse; border-spacing: 0;">
+            <tr>
+                <td style="padding: 0;">Ground Spawns</td>
+                <td style="padding: 0; text-align: right;">
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=17"><img
+                                src="images/add.gif" style="border: 0;" alt="Add Icon"
+                                title="Add an entry to this zone"></a>
+                </td>
+            </tr>
         </table>
-        <?endif;?>
-<? if (!isset($gspawn)):?>
+    </div>
+
+    <table class="table_content2" style="width: 100%;">
+        <?php if (isset($gspawn)): ?>
         <tr>
-          <td align="left" width="100" style="padding: 10px;">No ground spawns</td>
+            <td style="text-align: center; width: 5%"><strong>id</strong></td>
+            <td style="text-align: center; width: 20%"><strong>item</strong></td>
+            <td style="text-align: center; width: 5%"><strong>max</strong></td>
+            <td style="text-align: center; width: 5%"><strong>max x</strong></td>
+            <td style="text-align: center; width: 5%"><strong>max y</strong></td>
+            <td style="text-align: center; width: 5%"><strong>max z</strong></td>
+            <td style="text-align: center; width: 5%"><strong>min x</strong></td>
+            <td style="text-align: center; width: 5%"><strong>min y</strong></td>
+            <td style="text-align: center; width: 5%"><strong>respawn</strong></td>
+            <th style="width: 5%;"></th>
         </tr>
-<?endif;?>
+        <?php $x = 0;
+        foreach ($gspawn as $key => $v): ?>
+            <tr style="background-color: #<?php echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA"; ?>">
+                <td style="text-align: center; width: 5%"><?= $v['gsid'] ?></td>
+                <td style="text-align: center; width: 20%"><a
+                            href="index.php?editor=items&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&id=<?= $v['giid'] ?>&action=2"><?= $v['iname'] ?></a>
+                    <span>[<a href="https://lucy.allakhazam.com/item.html?id=<?= $v['giid'] ?>">lucy</a>]</span></td>
+                <td style="text-align: center; width: 5%"><?= $v['max_allowed'] ?></td>
+                <td style="text-align: center; width: 5%"><?= $v['max_x'] ?></td>
+                <td style="text-align: center; width: 5%"><?= $v['max_y'] ?></td>
+                <td style="text-align: center; width: 5%"><?= $v['max_z'] ?></td>
+                <td style="text-align: center; width: 5%"><?= $v['min_x'] ?></td>
+                <td style="text-align: center; width: 5%"><?= $v['min_y'] ?></td>
+                <td style="text-align: center; width: 5%"><?= $v['respawn_timer'] ?></td>
+                <td style="text-align: right;">
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&gsid=<?= $v['gsid'] ?>&action=14"><img
+                                src="images/edit2.gif" style="border: 0;" alt="Edit Icon" title="Edit Entry"></a>
+                    <a onClick="return confirm('Really Delete Entry <?= $v['gsid'] ?>?');"
+                       href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&gsid=<?= $v['gsid'] ?>&action=16"><img
+                                src="images/remove3.gif" style="border: 0;" alt="Remove Icon" title="Delete this entry"></a>
+                </td>
+            </tr>
+            <?php $x++; endforeach; ?>
+    </table>
+    <?php endif; ?>
+    <?php if (!isset($gspawn)): ?>
+    <tr>
+        <td style="text-align: left; width: 100px; padding: 10px;">No ground spawns</td>
+    </tr>
+<?php endif; ?>

--- a/templates/misc/groundspawn.view.tmpl.php
+++ b/templates/misc/groundspawn.view.tmpl.php
@@ -1,48 +1,53 @@
-      <div class="table_container" style="width: 600px;">
-      <div class="table_header">
-        <table width="100%" cellpadding="0" cellspacing="0">
-          <tr>
-           <td>Ground Spawns</td>
-           <td align="right">    
-          <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=17"><img src="images/add.gif" border="0" title="Add an entry to this zone"></a>
-            </td>
-           </tr>        
-         </table>
-      </div>
-
-       <table class="table_content2" width="100%">
-         <tr>
-          <td align="center" width="5%"><strong>id</strong></td>
-          <td align="center" width="10%"><strong>zone</strong></td>
-          <td align="center" width="10%"><strong>item</strong></td>
-          <td align="center" width="5%"><strong>max</strong></td>
-          <td align="center" width="5%"><strong>max x</strong></td>
-          <td align="center" width="5%"><strong>max y</strong></td>
-          <td align="center" width="5%"><strong>max z</strong></td>
-          <td align="center" width="5%"><strong>min x</strong></td>
-          <td align="center" width="5%"><strong>min y</strong></td>
-          <td align="center" width="5%"><strong>respawn</strong></td>
-          <th width="5%"></th>
-         </tr>
-        <tr bgcolor="#<? echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA";?>">
-          <td align="center" width="5%"><?=$gsid?></td>
-<?if($zoneid == 0):?>          
-          <td align="center" width="10%">All</td>
-<?endif;?>
-<?if($zoneid != 0):?> 
-          <td align="center" width="10%"><?=getZoneName($zoneid)?></td>
-<?endif;?>
-          <td align="center" width="10%"><?=get_item_name($giid)?> <span>[<a href="http://lucy.allakhazam.com/item.html?id=<?=$giid?>">lucy</a>]</span></td>
-          <td align="center" width="5%"><?=$max_allowed?></td>
-          <td align="center" width="5%"><?=$max_x?></td>
-          <td align="center" width="5%"><?=$max_y?></td>
-          <td align="center" width="5%"><?=$max_z?></td>
-          <td align="center" width="5%"><?=$min_x?></td>
-          <td align="center" width="5%"><?=$min_y?></td>
-          <td align="center" width="5%"><?=$respawn_timer?></td>  
-          <td align="right">      
-            <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&gsid=<?=$gsid?>&action=14"><img src="images/edit2.gif" border="0" title="Edit Entry"></a>          
-            <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&gsid=<?=$gsid?>&action=16"><img src="images/remove3.gif" border="0" title="Delete this entry"></a>
-          </td>
-        </tr>
+<div class="table_container" style="width: 600px;">
+    <div class="table_header">
+        <table style="width: 100%; border-collapse: collapse; border-spacing: 0;">
+            <tr>
+                <td style="padding: 0;">Ground Spawns</td>
+                <td style="padding: 0; text-align: right;">
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=17"><img
+                                src="images/add.gif" style="border: 0;" alt="Add Icon"
+                                title="Add an entry to this zone"></a>
+                </td>
+            </tr>
         </table>
+    </div>
+
+    <table class="table_content2" style="width: 100%;">
+        <tr>
+            <td style="text-align: center; width: 5%"><strong>id</strong></td>
+            <td style="text-align: center; width: 10%"><strong>zone</strong></td>
+            <td style="text-align: center; width: 10%"><strong>item</strong></td>
+            <td style="text-align: center; width: 5%"><strong>max</strong></td>
+            <td style="text-align: center; width: 5%"><strong>max x</strong></td>
+            <td style="text-align: center; width: 5%"><strong>max y</strong></td>
+            <td style="text-align: center; width: 5%"><strong>max z</strong></td>
+            <td style="text-align: center; width: 5%"><strong>min x</strong></td>
+            <td style="text-align: center; width: 5%"><strong>min y</strong></td>
+            <td style="text-align: center; width: 5%"><strong>respawn</strong></td>
+            <th style="width: 5%;"></th>
+        </tr>
+        <tr style="background-color: #<?php echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA"; ?>">
+            <td style="text-align: center; width: 5%"><?= $gsid ?? "" ?></td>
+            <?php if ($zoneid == 0): ?>
+                <td style="text-align: center; width: 10%">All</td>
+            <?php endif; ?>
+            <?php if ($zoneid != 0): ?>
+                <td style="text-align: center; width: 10%"><?= getZoneName($zoneid) ?></td>
+            <?php endif; ?>
+            <td style="text-align: center; width: 10%"><?= get_item_name($giid ?? "") ?> <span>[<a
+                            href="https://lucy.allakhazam.com/item.html?id=<?= $giid ?? "" ?>">lucy</a>]</span></td>
+            <td style="text-align: center; width: 5%"><?= $max_allowed ?? "" ?></td>
+            <td style="text-align: center; width: 5%"><?= $max_x ?? "" ?></td>
+            <td style="text-align: center; width: 5%"><?= $max_y ?? "" ?></td>
+            <td style="text-align: center; width: 5%"><?= $max_z ?? "" ?></td>
+            <td style="text-align: center; width: 5%"><?= $min_x ?? "" ?></td>
+            <td style="text-align: center; width: 5%"><?= $min_y ?? "" ?></td>
+            <td style="text-align: center; width: 5%"><?= $respawn_timer ?? "" ?></td>
+            <td style="text-align: right;">
+                <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&gsid=<?= $gsid ?? "" ?>&action=14"><img
+                            src="images/edit2.gif" style="border: 0;" alt="Edit Icon" title="Edit Entry"></a>
+                <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&gsid=<?= $gsid ?? "" ?>&action=16"><img
+                            src="images/remove3.gif" style="border: 0;" alt="Remove Icon" title="Delete this entry"></a>
+            </td>
+        </tr>
+    </table>

--- a/templates/misc/horses.add.tmpl.php
+++ b/templates/misc/horses.add.tmpl.php
@@ -1,44 +1,47 @@
 <div class="edit_form" style="width: 450px">
-      <div class="edit_form_header">
+    <div class="edit_form_header">
         Add Horse
-      </div>
+    </div>
 
-      <div class="edit_form_content">
-        <form name="horses" method="post" action=index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=34">
-        <table width="100%">
-          <tr>
-            <th>Filename</th>
-            <th>Texture</th>
-            <th>Speed</th>
-           </tr>
-          
-          <tr>
-            <td><input type="text" size="33" name="filename" value=""></td>
-            <td><input type="text" size="7" name="texture" value="0"></td>
-            <td><input type="text" size="15" name="mountspeed" value="1"></td>
-             </tr>
-             <tr>
-            <th>Race</th>
-            <th>Gender</th>
-            <th>Notes</th>
-          </tr>
-             <tr>
-            <td><select name="race"">
-<?foreach($races as $key=>$value):?>
-                   <option value="<?=$key?>"<?echo ($key == $race)? " selected" : "";?>><?=$key?>: <?=$value?></option>
-<?endforeach;?>
-                 </select></td>
-            <td><select name="gender">
-<?foreach($genders as $key=>$value):?>
-                   <option value="<?=$key?>"<?echo ($key == $gender)? " selected" : "";?>><?=$value?></option>
-<?endforeach;?>
-                 </select></td>
-             <td><input type="text" size="15" name="notes" value="Notes"></td>
-          </tr>
-         </table><br><br>
-        <center>
-          <input type="submit" value="Submit Changes">
-        </center>
-      </form>
-      </div>
-      </div>
+    <div class="edit_form_content">
+        <form name="horses" method="post"
+              action=index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=34">
+            <table style="width: 100%;">
+                <tr>
+                    <th><label for="filename">Filename</label></th>
+                    <th><label for="texture">Texture</label></th>
+                    <th><label for="mountspeed">Speed</label></th>
+                </tr>
+
+                <tr>
+                    <td><input type="text" size="33" id="filename" name="filename" value=""></td>
+                    <td><input type="text" size="7" id="texture" name="texture" value="0"></td>
+                    <td><input type="text" size="15" id="mountspeed" name="mountspeed" value="1"></td>
+                </tr>
+                <tr>
+                    <th><label for="race">Race</label></th>
+                    <th><label for="gender">Gender</label></th>
+                    <th><label for="notes">Notes</label></th>
+                </tr>
+                <tr>
+                    <td><select id="race" name="race"">
+                        <?php foreach ($races as $key => $value): ?>
+                            <option value="<?= $key ?>"<?php echo (isset($race) && $key == $race) ? " selected" : ""; ?>><?= $key ?>
+                                : <?= $value ?></option>
+                        <?php endforeach; ?>
+                        </select></td>
+                    <td><select id="gender" name="gender">
+                            <?php foreach ($genders as $key => $value): ?>
+                                <option value="<?= $key ?>"<?php echo (isset($gender) && $key == $gender) ? " selected" : ""; ?>><?= $value ?></option>
+                            <?php endforeach; ?>
+                        </select></td>
+                    <td><input type="text" size="15" id="notes" name="notes" value="Notes"></td>
+                </tr>
+            </table>
+            <br><br>
+            <div class="center">
+                <input type="submit" value="Submit Changes">
+            </div>
+        </form>
+    </div>
+</div>

--- a/templates/misc/horses.edit.tmpl.php
+++ b/templates/misc/horses.edit.tmpl.php
@@ -1,45 +1,49 @@
 <div class="edit_form" style="width: 450px">
-      <div class="edit_form_header">
-        Edit Horse <?=$filename?>
-      </div>
+    <div class="edit_form_header">
+        Edit Horse <?= $filename ?? "" ?>
+    </div>
 
-      <div class="edit_form_content">
-        <form name="horses" method="post" action=index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=31">
-        <table width="100%">
-          <tr>
-            <th>Filename</th>
-            <th>Texture</th>
-            <th>Speed</th>
-           </tr>
-          
-          <tr>
-            <td><input type="text" size="33" name="filenamea" value="<?=$filename?>"></td>
-            <td><input type="text" size="7" name="texture" value="<?=$texture?>"></td>
-            <td><input type="text" size="15" name="mountspeed" value="<?=$mountspeed?>"></td>
-             </tr>
-             <tr>
-            <th>Race</th>
-            <th>Gender</th>
-            <th>Notes</th>
-          </tr>
-             <tr>
-            <td><select name="race"">
-<?foreach($races as $key=>$value):?>
-                   <option value="<?=$key?>"<?echo ($key == $race)? " selected" : "";?>><?=$key?>: <?=$value?></option>
-<?endforeach;?>
-                 </select></td>
-            <td><select name="gender">
-<?foreach($genders as $key=>$value):?>
-                   <option value="<?=$key?>"<?echo ($key == $gender)? " selected" : "";?>><?=$value?></option>
-<?endforeach;?>
-                 </select></td>
-             <td><input type="text" size="15" name="notes" value="<?=$notes?>"></td>
-          </tr>
-         </table><br><br>
-        <center>
-          <input type="hidden" name="filename" value="<?=$filename?>">
-          <input type="submit" value="Submit Changes">
-        </center>
-      </form>
-      </div>
-      </div>
+    <div class="edit_form_content">
+        <form name="horses" method="post"
+              action=index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=31">
+            <table style="width: 100%;">
+                <tr>
+                    <th><label for="filename">Filename</label></th>
+                    <th><label for="texture">Texture</label></th>
+                    <th><label for="mountspeed">Speed</label></th>
+                </tr>
+
+                <tr>
+                    <td><input type="text" size="33" id="filename" name="filename" value="<?= $filename ?? "" ?>"></td>
+                    <td><input type="text" size="7" id="texture" name="texture" value="<?= $texture ?? "" ?>"></td>
+                    <td><input type="text" size="15" id="mountspeed" name="mountspeed" value="<?= $mountspeed ?? "" ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th><label for="race">Race</label></th>
+                    <th><label for="gender">Gender</label></th>
+                    <th><label for="notes">Notes</label></th>
+                </tr>
+                <tr>
+                    <td><select id="race" name="race"">
+                        <?php foreach ($races as $key => $value): ?>
+                            <option value="<?= $key ?>"<?php echo (isset($race) && $key == $race) ? " selected" : ""; ?>><?= $key ?>
+                                : <?= $value ?></option>
+                        <?php endforeach; ?>
+                        </select></td>
+                    <td><select id="gender" name="gender">
+                            <?php foreach ($genders as $key => $value): ?>
+                                <option value="<?= $key ?>"<?php echo (isset($gender) && $key == $gender) ? " selected" : ""; ?>><?= $value ?></option>
+                            <?php endforeach; ?>
+                        </select></td>
+                    <td><input type="text" size="15" id="notes" name="notes" value="<?= $notes ?? "" ?>"></td>
+                </tr>
+            </table>
+            <br><br>
+            <div class="center">
+                <input type="hidden" name="filename" value="<?= $filename ?? "" ?>">
+                <input type="submit" value="Submit Changes">
+            </div>
+        </form>
+    </div>
+</div>

--- a/templates/misc/horses.tmpl.php
+++ b/templates/misc/horses.tmpl.php
@@ -1,44 +1,50 @@
-      <div class="table_container" style="width: 700px;">
-      <div class="table_header">
-        <table width="100%" cellpadding="0" cellspacing="0">
-          <tr>
-           <td>Horses</td>
-           <td align="right">    
-          <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=33"><img src="images/add.gif" border="0" title="Add an entry to this zone"></a>
-            </td>
-           </tr>        
-         </table>
-      </div>
-
-       <table class="table_content2" width="100%">
-<? if (isset($horses)):?>
-         <tr>
-          <td align="center" width="12%"><strong>Filename</strong></td>
-          <td align="center" width="8%"><strong>Race</strong></td>
-          <td align="center" width="8%"><strong>Gender</strong></td>
-          <td align="center" width="8%"><strong>Texture</strong></td>
-          <td align="center" width="8%"><strong>Speed</strong></td>
-          <td align="center" width="12%"><strong>Notes</strong></td>
-          <th width="5%"></th>
-         </tr>
-<?$x=0; foreach($horses as $horses=>$v):?>
-        <tr bgcolor="#<? echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA";?>">
-          <td align="center" width="12%"><?=$v['filename']?></td>
-          <td align="center" width="8%"><?=$races[$v['race']]?></td>
-          <td align="center" width="8%"><?=$genders[$v['gender']]?></td>
-          <td align="center" width="8%"><?=$v['texture']?></td>   
-          <td align="center" width="8%"><?=$v['mountspeed']?></td>
-          <td align="center" width="12%"><?=$v['notes']?></td>
-          <td align="right">      
-            <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&filename=<?=$v['filename']?>&action=30"><img src="images/edit2.gif" border="0" title="Edit Entry"></a>          
-            <a onClick="return confirm('Really Delete Horse <?=$v['filename']?>?');" href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&filename=<?=$v['filename']?>&action=32"><img src="images/remove3.gif" border="0" title="Delete this entry"></a>
-          </td>
-        </tr>
-        <?$x++; endforeach;?>
+<div class="table_container" style="width: 700px;">
+    <div class="table_header">
+        <table style="width: 100%; border-collapse: collapse; border-spacing: 0;">
+            <tr>
+                <td style="padding: 0;">Horses</td>
+                <td style="padding: 0; text-align: right;">
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=33"><img
+                                src="images/add.gif" style="border: 0;" alt="Add Icon"
+                                title="Add an entry to this zone"></a>
+                </td>
+            </tr>
         </table>
-        <?endif;?>
-<? if (!isset($horses)):?>
+    </div>
+
+    <table class="table_content2" style="width: 100%;">
+        <?php if (isset($horses)): ?>
         <tr>
-          <td align="left" width="100" style="padding: 10px;">No horse data</td>
+            <td style="text-align: center; width: 12%"><strong>Filename</strong></td>
+            <td style="text-align: center; width: 8%"><strong>Race</strong></td>
+            <td style="text-align: center; width: 8%"><strong>Gender</strong></td>
+            <td style="text-align: center; width: 8%"><strong>Texture</strong></td>
+            <td style="text-align: center; width: 8%"><strong>Speed</strong></td>
+            <td style="text-align: center; width: 12%"><strong>Notes</strong></td>
+            <th style="width: 5%;"></th>
         </tr>
-<?endif;?>
+        <?php $x = 0;
+        foreach ($horses as $key => $v): ?>
+            <tr style="background-color: #<?php echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA"; ?>">
+                <td style="text-align: center; width: 12%"><?= $v['filename'] ?></td>
+                <td style="text-align: center; width: 8%"><?= $races[$v['race']] ?></td>
+                <td style="text-align: center; width: 8%"><?= $genders[$v['gender']] ?></td>
+                <td style="text-align: center; width: 8%"><?= $v['texture'] ?></td>
+                <td style="text-align: center; width: 8%"><?= $v['mountspeed'] ?></td>
+                <td style="text-align: center; width: 12%"><?= $v['notes'] ?></td>
+                <td style="text-align: right;">
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&filename=<?= $v['filename'] ?>&action=30"><img
+                                src="images/edit2.gif" style="border: 0;" alt="Edit Icon" title="Edit Entry"></a>
+                    <a onClick="return confirm('Really Delete Horse <?= $v['filename'] ?>?');"
+                       href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&filename=<?= $v['filename'] ?>&action=32"><img
+                                src="images/remove3.gif" style="border: 0;" alt="Remove Icon" title="Delete this entry"></a>
+                </td>
+            </tr>
+            <?php $x++; endforeach; ?>
+    </table>
+    <?php endif; ?>
+    <?php if (!isset($horses)): ?>
+    <tr>
+        <td style="text-align: left; width: 100px; padding: 10px;">No horse data</td>
+    </tr>
+<?php endif; ?>

--- a/templates/misc/misc.default.tmpl.php
+++ b/templates/misc/misc.default.tmpl.php
@@ -1,17 +1,29 @@
 <table class="edit_form">
-         <tr>
-           <td class="edit_form_header">
-             Options for <?=$currzone?>
-           </td>
-         </tr>
-         <tr>
-           <td class="edit_form_content">
-             <center><a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=1">Fishing for <?=$currzone?></a><br></center>
-             <center><a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=7">Forage for <?=$currzone?></a><br></center>
-             <center><a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=13">Ground Spawns in <?=$currzone?></a><br></center>
-             <center><a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=19">Traps in <?=$currzone?></a><br></center>
-             <center><a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=35">View Doors in <?=$currzone?></a><br></center>
-             <center><a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=41">View Objects in <?=$currzone?></a><br></center> 
-          </td>
-         </tr>
-       </table>
+    <tr>
+        <td class="edit_form_header">
+            Options for <?= $currzone ?? "" ?>
+        </td>
+    </tr>
+    <tr>
+        <td class="edit_form_content">
+            <div class="center"><a
+                        href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=1">Fishing
+                    for <?= $currzone ?? "" ?></a><br></div>
+            <div class="center"><a
+                        href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=7">Forage
+                    for <?= $currzone ?? "" ?></a><br></div>
+            <div class="center"><a
+                        href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=13">Ground
+                    Spawns in <?= $currzone ?? "" ?></a><br></div>
+            <div class="center"><a
+                        href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=19">Traps
+                    in <?= $currzone ?? "" ?></a><br></div>
+            <div class="center"><a
+                        href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=35">View
+                    Doors in <?= $currzone ?? "" ?></a><br></div>
+            <div class="center"><a
+                        href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=41">View
+                    Objects in <?= $currzone ?? "" ?></a><br></div>
+        </td>
+    </tr>
+</table>

--- a/templates/misc/misc.searchresults.tmpl.php
+++ b/templates/misc/misc.searchresults.tmpl.php
@@ -1,25 +1,25 @@
-    <div class="table_container" style="width:250px;">
-        <div class="table_header">
-          Misc Search Results
-        </div>
-        <div class="table_content">
-<?if($fishing != ''):?>
-<?foreach($fishing as $fishing): extract($fishing);?>
-          <a href="index.php?editor=misc&fsid=<?=$fsid?>&action=26"><?=get_item_name($fiid)?></a><br>
-<?endforeach;?>
-<?endif;?>
-<?if($forage != ''):?>
-<?foreach($forage as $forage): extract($forage);?>
-          <a href="index.php?editor=misc&fgid=<?=$fgid?>&action=27"><?=get_item_name($fgiid)?></a><br>
-<?endforeach;?>
-<?endif;?>
-<?if($gspawn != ''):?>
-<?foreach($gspawn as $gspawn): extract($gspawn);?>
-          <a href="index.php?editor=misc&gsid=<?=$gsid?>&action=28"><?=get_item_name($giid)?></a><br>
-<?endforeach;?>
-<?endif;?>
-<?if($fishing == '' && $forage == '' && $gspawn == ''):?>
-          Your search produced no results!
-<?endif;?>
-        </div>
-      </div>
+<div class="table_container" style="width:250px;">
+    <div class="table_header">
+        Misc Search Results
+    </div>
+    <div class="table_content">
+        <?php if (!empty($fishing)): ?>
+            <?php foreach ($fishing as $fishing_row): extract($fishing_row); ?>
+                <a href="index.php?editor=misc&fsid=<?= $fsid ?>&action=26"><?= get_item_name($fiid) ?></a><br>
+            <?php endforeach; ?>
+        <?php endif; ?>
+        <?php if (!empty($forage)): ?>
+            <?php foreach ($forage as $forage_row): extract($forage_row); ?>
+                <a href="index.php?editor=misc&fgid=<?= $fgid ?>&action=27"><?= get_item_name($fgiid) ?></a><br>
+            <?php endforeach; ?>
+        <?php endif; ?>
+        <?php if (!empty($gspawn)): ?>
+            <?php foreach ($gspawn as $gspawn_row): extract($gspawn_row); ?>
+                <a href="index.php?editor=misc&gsid=<?= $gsid ?>&action=28"><?= get_item_name($giid) ?></a><br>
+            <?php endforeach; ?>
+        <?php endif; ?>
+        <?php if (empty($fishing) && empty($forage) && empty($gspawn)): ?>
+            Your search produced no results!
+        <?php endif; ?>
+    </div>
+</div>

--- a/templates/misc/objects.add.tmpl.php
+++ b/templates/misc/objects.add.tmpl.php
@@ -1,48 +1,72 @@
 <div class="edit_form" style="width: 650px">
-      <div class="edit_form_header">
+    <div class="edit_form_header">
         Add Object
-      </div>
-      <div class="edit_form_content">
-        <form name="door" method="post" action=index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=46">
-        <table width="100%">
-          <tr>
-            <th>ID</th>
-            <th>x</th>
-            <th>y</th>
-            <th>z</th>
-            <th>heading</th>
-            <th>type</th> 
-          </tr>
-          <tr>
-            <td><input type="text" size="7" name="objid" value="<?=$suggestobjid?>"></td>
-            <td><input type="text" size="7" name="xpos" value="0"></td>
-            <td><input type="text" size="7" name="ypos" value="0"></td>
-            <td><input type="text" size="7" name="zpos" value="0"></td>
-            <td><input type="text" size="7" name="heading" value="0"></td>
-            <td><select class="left" name="type">
-<?foreach($world_containers as $k => $v):?>
-              <option value="<?=$k?>"<? echo ($k == $type) ? " selected" : ""?>><?=$v?></option>
-<?endforeach;?>       
-           </td> 
-           </tr>
-          <tr>  
-            <th>item</th>
-            <th>charges</th>
-            <th>icon</th>  
-            <th>&nbsp;</th>
-            <th>name</th>     
-          </tr>
-          <tr>    
-            <td><input type="text" size="7" name="itemid" value="0"></td>
-            <td><input type="text" size="7" name="charges" value="0"></td>  
-            <td><input type="text" size="7" name="icon" value="0"></td>    
-            <td align="left">&nbsp;</td>
-            <td><input type="text" size="20" name="objectname" value="ITxxxxx_ACTORDEF"></td>  
-          </tr>
-              </table><br><br>
-        <center>
-          <input type="submit" value="Submit Changes">
-        </center>
-      </form>
-      </div>
-      </div>
+    </div>
+    <div class="edit_form_content">
+        <form name="door" method="post"
+              action=index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=46">
+            <div style="padding-bottom: 20px;">
+                <fieldset>
+                    <legend>Object Identity</legend>
+                    <table style="width: 100%; border-spacing: 20px;">
+                        <tr>
+                            <th colspan="2"><label for="objid">ID</label></th>
+                            <th colspan="2"><label for="objectname">name</label></th>
+                        </tr>
+                        <tr>
+                            <td colspan="2"><input type="text" size="7" id="objid" name="objid"
+                                                   value="<?= $suggestobjid ?? "" ?>"></td>
+                            <td colspan="2"><input type="text" size="20" id="objectname" name="objectname"
+                                                   value="ITxxxxx_ACTORDEF"></td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div style="padding-bottom: 20px;">
+                <fieldset>
+                    <legend>Object Location</legend>
+                    <table style="width: 100%;">
+                        <tr>
+                            <th><label for="xpos">x</label></th>
+                            <th><label for="ypos">y</label></th>
+                            <th><label for="zpos">z</label></th>
+                            <th><label for="heading">heading</label></th>
+                        </tr>
+                        <tr>
+                            <td><input type="text" size="7" id="xpos" name="xpos" value="0"></td>
+                            <td><input type="text" size="7" id="ypos" name="ypos" value="0"></td>
+                            <td><input type="text" size="7" id="zpos" name="zpos" value="0"></td>
+                            <td><input type="text" size="7" id="heading" name="heading" value="0"></td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div style="padding-bottom: 20px;">
+                <fieldset>
+                    <legend>Object Details</legend>
+                    <table style="width: 100%;">
+                        <tr>
+                            <th><label for="itemid">item</label></th>
+                            <th><label for="charges">charges</label></th>
+                            <th><label for="icon">icon</label></th>
+                            <th><label for="type">type</label></th>
+                        </tr>
+                        <tr>
+                            <td><input type="text" size="7" id="itemid" name="itemid" value="0"></td>
+                            <td><input type="text" size="7" id="charges" name="charges" value="0"></td>
+                            <td><input type="text" size="7" id="icon" name="icon" value="0"></td>
+                            <td><select class="left" id="type" name="type">
+                                    <?php foreach ($world_containers as $k => $v): ?>
+                                        <option value="<?= $k ?>"<?php echo (isset($type) && $k == $type) ? " selected" : "" ?>><?= $v ?></option>
+                                    <?php endforeach; ?>
+                            </td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div class="center">
+                <input type="submit" value="Submit Changes">
+            </div>
+        </form>
+    </div>
+</div>

--- a/templates/misc/objects.edit.tmpl.php
+++ b/templates/misc/objects.edit.tmpl.php
@@ -1,45 +1,72 @@
 <div class="edit_form" style="width: 550px">
-      <div class="edit_form_header">
-        Object: <?=$id?>
-      </div>
-
-      <div class="edit_form_content">
-        <form name="door" method="post" action=index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=43">
-        <table width="100%">
-          <tr>
-            <th>x</th>
-            <th>y</th>
-            <th>z</th>
-            <th>heading</th>
-            <th>name</th>           
-          </tr>
-          <tr>
-            <td><input type="text" size="7" name="xpos" value="<?=$xpos?>"></td>
-            <td><input type="text" size="7" name="ypos" value="<?=$ypos?>"></td>
-            <td><input type="text" size="7" name="zpos" value="<?=$zpos?>"></td>
-            <td><input type="text" size="7" name="heading" value="<?=$heading?>"></td>  
-            <td><input type="text" size="20" name="objectname" value="<?=$objectname?>"></td>
-           </tr>
-          <tr>
-            <th>item</th>
-            <th>charges</th>
-            <th>icon</th> 
-            <th>type</th>              
-          </tr>
-          <tr>
-            <td><input type="text" size="7" name="itemid" value="<?=$itemid?>"></td>
-            <td><input type="text" size="7" name="charges" value="<?=$charges?>"></td> 
-            <td><input type="text" size="7" name="icon" value="<?=$icon?>"></td>     
-                 <td><select class="left" name="type">
-<?foreach($world_containers as $k => $v):?>
-              <option value="<?=$k?>"<? echo ($k == $type) ? " selected" : ""?>><?=$v?></option>
-<?endforeach;?>       
-           </td>  
-              </table><br><br>
-        <center>
-          <input type="hidden" name="objid" value="<?=$id?>">
-          <input type="submit" value="Submit Changes">
-        </center>
-      </form>
-      </div>
-      </div>
+    <div class="edit_form_header">
+        Edit Object: <?= $id ?>
+    </div>
+    <div class="edit_form_content">
+        <form name="door" method="post"
+              action=index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=43">
+            <div style="padding-bottom: 20px;">
+                <fieldset>
+                    <legend>Object Identity</legend>
+                    <table style="width: 100%;">
+                        <tr>
+                            <th><label for="objectname">name</label></th>
+                        </tr>
+                        <tr>
+                            <td><input type="text" size="20" id="objectname" name="objectname"
+                                       value="<?= $objectname ?? "" ?>">
+                            </td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div style="padding-bottom: 20px;">
+                <fieldset>
+                    <legend>Object Location</legend>
+                    <table style="width: 100%;">
+                        <tr>
+                            <th><label for="xpos">x</label></th>
+                            <th><label for="ypos">y</label></th>
+                            <th><label for="zpos">z</label></th>
+                            <th><label for="heading">heading</label></th>
+                        </tr>
+                        <tr>
+                            <td><input type="text" size="7" id="xpos" name="xpos" value="<?= $xpos ?? "" ?>"></td>
+                            <td><input type="text" size="7" id="ypos" name="ypos" value="<?= $ypos ?? "" ?>"></td>
+                            <td><input type="text" size="7" id="zpos" name="zpos" value="<?= $zpos ?? "" ?>"></td>
+                            <td><input type="text" size="7" id="heading" name="heading" value="<?= $heading ?? "" ?>">
+                            </td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div style="padding-bottom: 20px;">
+                <fieldset>
+                    <legend>Object Details</legend>
+                    <table style="width: 100%;">
+                        <tr>
+                            <th><label for="itemid">item</label></th>
+                            <th><label for="charges">charges</label></th>
+                            <th><label for="icon">icon</label></th>
+                            <th><label for="type">type</label></th>
+                        </tr>
+                        <tr>
+                            <td><input type="text" size="7" id="itemid" name="itemid" value="<?= $itemid ?? "" ?>"></td>
+                            <td><input type="text" size="7" id="charges" name="charges" value="<?= $charges ?? "" ?>"></td>
+                            <td><input type="text" size="7" id="icon" name="icon" value="<?= $icon ?? "" ?>"></td>
+                            <td><select class="left" id="type" name="type">
+                                    <?php foreach ($world_containers as $k => $v): ?>
+                                        <option value="<?= $k ?>"<?php echo (isset($type) && $k == $type) ? " selected" : "" ?>><?= $v ?></option>
+                                    <?php endforeach; ?>
+                            </td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div class="center">
+                <input type="hidden" name="objid" value="<?= $id ?>">
+                <input type="submit" value="Submit Changes">
+            </div>
+        </form>
+    </div>
+</div>

--- a/templates/misc/objects.tmpl.php
+++ b/templates/misc/objects.tmpl.php
@@ -1,57 +1,65 @@
-        <div class="table_container" style="width: 750px;">
-        <div class="table_header">
-          <table width="100%" cellpadding="0" cellspacing="0">
+<div class="table_container" style="width: 750px;">
+    <div class="table_header">
+        <table style="width: 100%; border-collapse: collapse; border-spacing: 0;">
             <tr>
-             <td>Objects</td>
-             <td align="right">    
-            <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=45"><img src="images/add.gif" border="0" title="Add an entry to this zone"></a>
-              </td>
-             </tr>        
-           </table>
-        </div>
-  
-         <table class="table_content2" width="100%">
-  <? if (isset($objects)):?>
-           <tr>
-            <td align="center" width="2%"><strong>ID</strong></td>
-            <td align="center" width="2%"><strong>X</strong></td>
-            <td align="center" width="2%"><strong>Y</strong></td>
-            <td align="center" width="2%"><strong>Z</strong></td>
-            <td align="center" width="2%"><strong>Heading</strong></td>
-            <td align="center" width="2%"><strong>Item</strong></td>
-            <td align="center" width="2%"><strong>Charges</strong></td>
-            <td align="center" width="2%"><strong>Name</strong></td>
-            <td align="center" width="2%"><strong>Type</strong></td>
-            <td align="center" width="2%"><strong>Icon</strong></td>
-            <th width="5%"></th>
-           </tr>
-  <?$x=0; foreach($objects as $objects=>$v):?>
-          <tr bgcolor="#<? echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA";?>">
-            <td align="center" width="2%"><?=$v['objid']?></td>
-            <td align="center" width="2%"><?=$v['xpos']?></td>   
-            <td align="center" width="2%"><?=$v['ypos']?></td>
-            <td align="center" width="2%"><?=$v['zpos']?></td>
-            <td align="center" width="2%"><?=$v['heading']?></td> 
-  <?if($v['itemid'] < 1):?>  
-            <td align="center" width="2%"><?=$v['itemid']?></td> 
-  <?endif;?>
-  <?if($v['itemid'] > 0):?>  
-            <td align="center" width="2%"><?=get_item_name($v['itemid'])?> <span>[<a href="http://lucy.allakhazam.com/item.html?id=<?=$v['itemid']?>">lucy</a>]</span></td>
-  <?endif;?>
-            <td align="center" width="2%"><?=$v['charges']?></td> 
-            <td align="center" width="2%"><?=$v['objectname']?></td>   
-            <td align="center" width="2%"><?=$world_containers[$v['type']]?></td>
-            <td align="center" width="2%"><?=$v['icon']?></td>
-            <td align="right">      
-              <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&objid=<?=$v['objid']?>&action=42"><img src="images/edit2.gif" border="0" title="Edit Entry"></a>          
-              <a onClick="return confirm('Really Delete Object <?=$v['objid']?>?');" href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&objid=<?=$v['objid']?>&action=44"><img src="images/remove3.gif" border="0" title="Delete this entry"></a>
-            </td>
-          </tr>
-          <?$x++; endforeach;?>
-          </table>
-          <?endif;?>
-  <? if (!isset($objects)):?>
-          <tr>
-            <td align="left" width="100" style="padding: 10px;">No objects</td>
-          </tr>
-<?endif;?>
+                <td style="padding: 0;">Objects</td>
+                <td style="padding: 0; text-align: right;">
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=45"><img
+                                src="images/add.gif" style="border: 0;" alt="Add Icon"
+                                title="Add an entry to this zone"></a>
+                </td>
+            </tr>
+        </table>
+    </div>
+
+    <table class="table_content2" style="width: 100%;">
+        <?php if (isset($objects)): ?>
+        <tr>
+            <td style="text-align: center; width: 2%"><strong>ID</strong></td>
+            <td style="text-align: center; width: 2%"><strong>X</strong></td>
+            <td style="text-align: center; width: 2%"><strong>Y</strong></td>
+            <td style="text-align: center; width: 2%"><strong>Z</strong></td>
+            <td style="text-align: center; width: 2%"><strong>Heading</strong></td>
+            <td style="text-align: center; width: 2%"><strong>Item</strong></td>
+            <td style="text-align: center; width: 2%"><strong>Charges</strong></td>
+            <td style="text-align: center; width: 2%"><strong>Name</strong></td>
+            <td style="text-align: center; width: 2%"><strong>Type</strong></td>
+            <td style="text-align: center; width: 2%"><strong>Icon</strong></td>
+            <th style="width: 5%;"></th>
+        </tr>
+        <?php $x = 0;
+        foreach ($objects as $key => $v): ?>
+            <tr style="background-color: #<?php echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA"; ?>">
+                <td style="text-align: center; width: 2%"><?= $v['objid'] ?></td>
+                <td style="text-align: center; width: 2%"><?= $v['xpos'] ?></td>
+                <td style="text-align: center; width: 2%"><?= $v['ypos'] ?></td>
+                <td style="text-align: center; width: 2%"><?= $v['zpos'] ?></td>
+                <td style="text-align: center; width: 2%"><?= $v['heading'] ?></td>
+                <?php if ($v['itemid'] < 1): ?>
+                    <td style="text-align: center; width: 2%"><?= $v['itemid'] ?></td>
+                <?php endif; ?>
+                <?php if ($v['itemid'] > 0): ?>
+                    <td style="text-align: center; width: 2%"><?= get_item_name($v['itemid']) ?> <span>[<a
+                                    href="https://lucy.allakhazam.com/item.html?id=<?= $v['itemid'] ?>">lucy</a>]</span>
+                    </td>
+                <?php endif; ?>
+                <td style="text-align: center; width: 2%"><?= $v['charges'] ?></td>
+                <td style="text-align: center; width: 2%"><?= $v['objectname'] ?></td>
+                <td style="text-align: center; width: 2%"><?= $world_containers[$v['type']] ?></td>
+                <td style="text-align: center; width: 2%"><?= $v['icon'] ?></td>
+                <td style="text-align: right;">
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&objid=<?= $v['objid'] ?>&action=42"><img
+                                src="images/edit2.gif" style="border: 0;" alt="Edit Icon" title="Edit Entry"></a>
+                    <a onClick="return confirm('Really Delete Object <?= $v['objid'] ?>?');"
+                       href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&objid=<?= $v['objid'] ?>&action=44"><img
+                                src="images/remove3.gif" style="border: 0;" alt="Remove Icon" title="Delete this entry"></a>
+                </td>
+            </tr>
+            <?php $x++; endforeach; ?>
+    </table>
+    <?php endif; ?>
+    <?php if (!isset($objects)): ?>
+    <tr>
+        <td style="text-align: left; width: 100px; padding: 10px;">No objects</td>
+    </tr>
+<?php endif; ?>

--- a/templates/misc/traps.add.tmpl.php
+++ b/templates/misc/traps.add.tmpl.php
@@ -1,92 +1,190 @@
-  <center>
+<div class="center">
     <table style="border: 1px solid black; background-color: #CCC;">
-      <tr><td colspan="3"><b>Legend:</b></td></tr>
-      <tr><td align="right"><b>Casting:</b></td><td>&nbsp;</td><td><i>Value1:</i> SpellID</td><td align="left"><i>Value2:</i>  Not Used</td><td>&nbsp;</td></tr>
-      <tr><td align="right"><b>Alarm:</b></td><td>&nbsp;</td><td><i>Value1:</i>  Range</td><td align="left"><i>Value2:</i>  0: Aggro All 1: Aggro KOS only</td><td>&nbsp;</td></tr>
-      <tr><td align="right"><b>Mystics:</b></td><td>&nbsp;</td><td><i>Value1:</i>  NPCID</td><td align="left"><i>Value2:</i>  Number of NPCs</td><td>&nbsp;</td></tr>
-      <tr><td align="right"><b>Bandits:</b></td><td>&nbsp;</td><td><i>Value1:</i>  NPCID</td><td align="left"><i>Value2:</i>  Number of NPCs</td><td>&nbsp;</td></tr>
-      <tr><td align="right"><b>Damage:</b></td><td>&nbsp;</td><td><i>Value1:</i>  MinDmg</td><td align="left"><i>Value2:</i>  MaxDmg</td><td>&nbsp;</td></tr>
-    </table><br/><br/>
-  </center>
+        <tr>
+            <td colspan="3"><b>Legend:</b></td>
+        </tr>
+        <tr>
+            <td style="text-align: right;"><b>Casting:</b></td>
+            <td>&nbsp;</td>
+            <td><i>Value1:</i> SpellID</td>
+            <td style="text-align: left;"><i>Value2:</i> Not Used</td>
+            <td>&nbsp;</td>
+        </tr>
+        <tr>
+            <td style="text-align: right;"><b>Alarm:</b></td>
+            <td>&nbsp;</td>
+            <td><i>Value1:</i> Range</td>
+            <td style="text-align: left;"><i>Value2:</i> 0: Aggro All 1: Aggro KOS only</td>
+            <td>&nbsp;</td>
+        </tr>
+        <tr>
+            <td style="text-align: right;"><b>Mystics:</b></td>
+            <td>&nbsp;</td>
+            <td><i>Value1:</i> NPCID</td>
+            <td style="text-align: left;"><i>Value2:</i> Number of NPCs</td>
+            <td>&nbsp;</td>
+        </tr>
+        <tr>
+            <td style="text-align: right;"><b>Bandits:</b></td>
+            <td>&nbsp;</td>
+            <td><i>Value1:</i> NPCID</td>
+            <td style="text-align: left;"><i>Value2:</i> Number of NPCs</td>
+            <td>&nbsp;</td>
+        </tr>
+        <tr>
+            <td style="text-align: right;"><b>Damage:</b></td>
+            <td>&nbsp;</td>
+            <td><i>Value1:</i> MinDmg</td>
+            <td style="text-align: left;"><i>Value2:</i> MaxDmg</td>
+            <td>&nbsp;</td>
+        </tr>
+    </table>
+    <br/><br/>
+</div>
 <div class="edit_form" style="width: 750px">
-      <div class="edit_form_header">
+    <div class="edit_form_header">
         Add Trap
-      </div>
+    </div>
 
-      <div class="edit_form_content">
-        <form name="traps" method="post" action=index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=24">
-        <table width="100%">
-          <tr>
-            <th>id</th>
-            <th>zone</th>
-            <th>x</th>
-            <th>y</th>
-            <th>z</th>
-            <th>maxzdiff</th>
-            <th>radius</th>
-            <th>triggered num</th>
-            <th>group</th>
-          </tr>
-          <tr>
-            <td><input type="text" size="7" name="tid" value="<?=$suggesttid?>"></td>
-            <td><input type="text" size="10" name="zone" value="<?=$currzone?>"></td>
-            <td><input type="text" size="7" name="x_coord" value="0"></td>
-            <td><input type="text" size="7" name="y_coord" value="0"></td>
-            <td><input type="text" size="7" name="z_coord" value="0"></td>
-            <td><input type="text" size="7" name="maxzdiff" value="10"></td>
-            <td><input type="text" size="7" name="radius" value="25"></td>
-            <td><input type="text" size="7" name="triggered_number" value="0"></td>
-            <td><input type="text" size="7" name="group" value="0"></td>
-          </tr>
-          <tr>
-            
-            <th>effectvalue</th>
-            <th>effectvalue2</th>
-            <th>chance</th>
-            <th>skill</th>
-            <th>level</th>
-            <th>respawn</th>
-            <th>variance</th>
-            <th>effect</th>
-          </tr>
-          <tr>
-            <td><input type="text" size="7" name="effectvalue" value="0"></td>
-            <td><input type="text" size="10" name="effectvalue2" value="0"></td>
-            <td><input type="text" size="7" name="chance" value="100"></td>
-            <td><input type="text" size="7" name="skill" value="1"></td>
-            <td><input type="text" size="7" name="level" value="1"></td>
-            <td><input type="text" size="7" name="respawn_time" value="600"></td>
-            <td><input type="text" size="7" name="respawn_var" value="0"></td>
-            <td><select class="left" name="effect">
-<?foreach($traptype as $k => $v):?>
-              <option value="<?=$k?>"<? echo ($k == $effect) ? " selected" : ""?>><?=$v?></option>
-<?$x++; endforeach;?>
-           </td> 
-          </tr>    
-          </table>
-          <table width="100%">   
-            <tr>
-            <th>message</th>
-            <th>despawn when triggered</th>
-            <th>undetectable</th>
-           </tr>       
-          <tr>
-             <td><input type="text" size="75" name="message" value=""></td>  
-             <td><select class="left" name="despawn_when_triggered">
-<?foreach($yesno as $k => $v):?>
-              <option value="<?=$k?>"<? echo ($k == $despawn_when_triggered) ? " selected" : ""?>><?=$v?></option>
-<?$x++; endforeach;?>
-           </td> 
-          <td><select class="left" name="undetectable">
-<?foreach($yesno as $k => $v):?>
-              <option value="<?=$k?>"<? echo ($k == $undetectable) ? " selected" : ""?>><?=$v?></option>
-<?$x++; endforeach;?>
-           </td> 
-          </tr>
-           </table><br><br>
-        <center>
-          <input type="submit" value="Submit Changes">
-        </center>
-      </form>
-      </div>
-      </div>
+    <div class="edit_form_content">
+        <form name="traps" method="post"
+              action=index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=24">
+            <div style="padding-bottom: 20px;">
+                <fieldset>
+                    <legend>General Information</legend>
+                    <table style="width: 100%;">
+                        <tr>
+                            <th><label for="tid">id</label></th>
+                            <th><label for="skill">skill</label></th>
+                            <th><label for="level">level</label></th>
+                        </tr>
+                        <tr>
+                            <td style="padding-bottom: 10px;"><input type="text" size="7" id="tid" name="tid"
+                                                                     value="<?= $suggesttid ?? "" ?>"></td>
+                            <td style="padding-bottom: 10px;"><input type="text" size="7" id="skill" name="skill"
+                                                                     value="1"></td>
+                            <td style="padding-bottom: 10px;"><input type="text" size="7" id="level" name="level"
+                                                                     value="1"></td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div style="padding-bottom: 20px;">
+                <fieldset>
+                    <legend>Trap Placement</legend>
+                    <table style="width: 100%;">
+                        <tr>
+                            <th><label for="zone">zone</label></th>
+                            <th><label for="x_coord">x</label></th>
+                            <th><label for="y_coord">y</label></th>
+                            <th><label for="z_coord">z</label></th>
+                        </tr>
+                        <tr>
+                            <td style="padding-bottom: 10px;"><input type="text" size="10" id="zone" name="zone"
+                                                                     value="<?= $currzone ?? "" ?>"></td>
+                            <td style="padding-bottom: 10px;"><input type="text" size="7" id="x_coord" name="x_coord"
+                                                                     value="0"></td>
+                            <td style="padding-bottom: 10px;"><input type="text" size="7" id="y_coord" name="y_coord"
+                                                                     value="0"></td>
+                            <td style="padding-bottom: 10px;"><input type="text" size="7" id="z_coord" name="z_coord"
+                                                                     value="0"></td>
+                        </tr>
+                        <tr>
+                            <th><label for="maxzdiff">maxzdiff</label></th>
+                            <th><label for="radius">radius</label></th>
+                            <th><label for="triggered_number">triggered num</label></th>
+                            <th><label for="group">group</label></th>
+                        </tr>
+                        <tr>
+                            <td style="padding-bottom: 10px;"><input type="text" size="7" id="maxzdiff" name="maxzdiff"
+                                                                     value="10"></td>
+                            <td style="padding-bottom: 10px;"><input type="text" size="7" id="radius" name="radius"
+                                                                     value="25"></td>
+                            <td style="padding-bottom: 10px;"><input type="text" size="7" id="triggered_number"
+                                                                     name="triggered_number" value="0">
+                            </td>
+                            <td style="padding-bottom: 10px;"><input type="text" size="7" id="group" name="group"
+                                                                     value="0"></td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div style="padding-bottom: 20px;">
+                <fieldset>
+                    <legend>Effects</legend>
+                    <table style="width: 100%;">
+                        <tr>
+
+                            <th><label for="effect">effect</label></th>
+                            <th><label for="effectvalue">effectvalue</label></th>
+                            <th><label for="effectvalue2">effectvalue2</label></th>
+                            <th colspan="2"><label for="undetectable">undetectable</label></th>
+                        </tr>
+                        <tr>
+                            <td style="padding-bottom: 10px;"><select class="left" id="effect" name="effect">
+                                    <?php foreach ($traptype as $k => $v): ?>
+                                        <option value="<?= $k ?>"<?php echo (isset($effect) && $k == $effect) ? " selected" : "" ?>><?= $v ?></option>
+                                        <?php $x++; endforeach; ?>
+                            </td>
+                            <td style="padding-bottom: 10px;"><input type="text" size="7" id="effectvalue"
+                                                                     name="effectvalue" value="0"></td>
+                            <td style="padding-bottom: 10px;"><input type="text" size="10" id="effectvalue2"
+                                                                     name="effectvalue2" value="0"></td>
+                            <td style="padding-bottom: 10px;" colspan="2"><select class="left" id="undetectable"
+                                                                                  name="undetectable">
+                                    <?php foreach ($yesno as $k => $v): ?>
+                                        <option value="<?= $k ?>"<?php echo (isset($undetectable) && $k == $undetectable) ? " selected" : "" ?>><?= $v ?></option>
+                                        <?php $x++; endforeach; ?>
+                            </td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div style="padding-bottom: 20px;">
+                <fieldset>
+                    <legend>Spawn Information</legend>
+                    <table style="width: 100%;">
+                        <tr>
+                            <th><label for="chance">chance</label></th>
+                            <th><label for="respawn_var">variance</label></th>
+                            <th><label for="respawn_time">respawn</label></th>
+                            <th colspan="2"><label for="despawn_when_triggered">despawn when triggered</label></th>
+                        </tr>
+                        <tr>
+                            <td style="padding-bottom: 10px;"><input type="text" size="7" id="chance" name="chance"
+                                                                     value="100"></td>
+                            <td style="padding-bottom: 10px;"><input type="text" size="7" id="respawn_var"
+                                                                     name="respawn_var" value="0"></td>
+                            <td style="padding-bottom: 10px;"><input type="text" size="7" id="respawn_time"
+                                                                     name="respawn_time" value="600"></td>
+                            <td style="padding-bottom: 10px;" colspan="2"><select class="left"
+                                                                                  id="despawn_when_triggered"
+                                                                                  name="despawn_when_triggered">
+                                    <?php foreach ($yesno as $k => $v): ?>
+                                        <option value="<?= $k ?>"<?php echo (isset($despawn_when_triggered) && $k == $despawn_when_triggered) ? " selected" : "" ?>><?= $v ?></option>
+                                        <?php $x++; endforeach; ?>
+                            </td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div style="padding-bottom: 20px;">
+                <fieldset>
+                    <legend>Trap Message</legend>
+                    <table style="width: 100%;">
+                        <tr>
+                            <th><label for="message">message</label></th>
+                        </tr>
+                        <tr>
+                            <td style="padding: 10px;"><input type="text" size="80" id="message" name="message"
+                                                              value=""></td>
+                        </tr>
+                    </table>
+                </fieldset>
+            </div>
+            <div class="center">
+                <input type="submit" value="Submit Changes">
+            </div>
+        </form>
+    </div>
+</div>

--- a/templates/misc/traps.edit.tmpl.php
+++ b/templates/misc/traps.edit.tmpl.php
@@ -1,88 +1,128 @@
-  <center>
+<div class="center">
     <table style="border: 1px solid black; background-color: #CCC;">
-      <tr><td colspan="3"><b>Legend:</b></td></tr>
-      <tr><td align="right"><b>Casting:</b></td><td>&nbsp;</td><td><i>Value1:</i> SpellID</td><td align="left"><i>Value2:</i>  Not Used</td><td>&nbsp;</td></tr>
-      <tr><td align="right"><b>Alarm:</b></td><td>&nbsp;</td><td><i>Value1:</i>  Range</td><td align="left"><i>Value2:</i>  0: Aggro All 1: Aggro KOS only</td><td>&nbsp;</td></tr>
-      <tr><td align="right"><b>Mystics:</b></td><td>&nbsp;</td><td><i>Value1:</i>  NPCID</td><td align="left"><i>Value2:</i>  Number of NPCs</td><td>&nbsp;</td></tr>
-      <tr><td align="right"><b>Bandits:</b></td><td>&nbsp;</td><td><i>Value1:</i>  NPCID</td><td align="left"><i>Value2:</i>  Number of NPCs</td><td>&nbsp;</td></tr>
-      <tr><td align="right"><b>Damage:</b></td><td>&nbsp;</td><td><i>Value1:</i>  MinDmg</td><td align="left"><i>Value2:</i>  MaxDmg</td><td>&nbsp;</td></tr>
-    </table><br/><br/>
-  </center>
+        <tr>
+            <td colspan="3"><b>Legend:</b></td>
+        </tr>
+        <tr>
+            <td style="text-align: right;"><b>Casting:</b></td>
+            <td>&nbsp;</td>
+            <td><i>Value1:</i> SpellID</td>
+            <td style="text-align: left;"><i>Value2:</i> Not Used</td>
+            <td>&nbsp;</td>
+        </tr>
+        <tr>
+            <td style="text-align: right;"><b>Alarm:</b></td>
+            <td>&nbsp;</td>
+            <td><i>Value1:</i> Range</td>
+            <td style="text-align: left;"><i>Value2:</i> 0: Aggro All 1: Aggro KOS only</td>
+            <td>&nbsp;</td>
+        </tr>
+        <tr>
+            <td style="text-align: right;"><b>Mystics:</b></td>
+            <td>&nbsp;</td>
+            <td><i>Value1:</i> NPCID</td>
+            <td style="text-align: left;"><i>Value2:</i> Number of NPCs</td>
+            <td>&nbsp;</td>
+        </tr>
+        <tr>
+            <td style="text-align: right;"><b>Bandits:</b></td>
+            <td>&nbsp;</td>
+            <td><i>Value1:</i> NPCID</td>
+            <td style="text-align: left;"><i>Value2:</i> Number of NPCs</td>
+            <td>&nbsp;</td>
+        </tr>
+        <tr>
+            <td style="text-align: right;"><b>Damage:</b></td>
+            <td>&nbsp;</td>
+            <td><i>Value1:</i> MinDmg</td>
+            <td style="text-align: left;"><i>Value2:</i> MaxDmg</td>
+            <td>&nbsp;</td>
+        </tr>
+    </table>
+    <br/><br/>
+</div>
 <div class="edit_form" style="width: 750px">
-      <div class="edit_form_header">
-        Edit Trap: <?=$id?>
-      </div>
-      <div class="edit_form_content">
-        <form name="traps" method="post" action=index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=21">
-        <table width="100%">
-          <tr>
-            <th>x</th>
-            <th>y</th>
-            <th>z</th>
-            <th>maxzdiff</th>
-            <th>radius</th>
-            <th>chance</th>
-            <th>triggered num</th>
-            <th>group</th>
-          </tr>
-          <tr>
-            <td><input type="text" size="7" name="x_coord" value="<?=$x?>"></td>
-            <td><input type="text" size="7" name="y_coord" value="<?=$y?>"></td>
-            <td><input type="text" size="7" name="z_coord" value="<?=$z?>"></td>
-            <td><input type="text" size="7" name="maxzdiff" value="<?=$maxzdiff?>"></td>
-            <td><input type="text" size="7" name="radius" value="<?=$radius?>"></td>
-            <td><input type="text" size="7" name="chance" value="<?=$chance?>"></td> 
-            <td><input type="text" size="7" name="triggered_number" value="<?=$triggered_number?>"></td> 
-            <td><input type="text" size="7" name="group" value="<?=$group?>"></td>
-          </tr>
-          <tr>  
-            <th>effectvalue</th>
-            <th>effectvalue2</th>
-            <th>skill</th>
-            <th>level</th>
-            <th>respawn</th>
-            <th>variance</th>
-            <th>effect</th>
-          </tr>
-          <tr>
-            <td><input type="text" size="7" name="effectvalue" value="<?=$effectvalue?>"></td>
-            <td><input type="text" size="7" name="effectvalue2" value="<?=$effectvalue2?>"></td>
-            <td><input type="text" size="7" name="skill" value="<?=$skill?>"></td>
-            <td><input type="text" size="7" name="level" value="<?=$level?>"></td>
-            <td><input type="text" size="7" name="respawn_time" value="<?=$respawn_time?>"></td>
-            <td><input type="text" size="7" name="respawn_var" value="<?=$respawn_var?>"></td>
-            <td><select class="left" name="effect">
-<?foreach($traptype as $k => $v):?>
-              <option value="<?=$k?>"<? echo ($k == $effect) ? " selected" : ""?>><?=$v?></option>
-<?endforeach;?>       
-           </select></td>
-          </tr>     
-          </table>
-          <table width="100%">       
-            <tr>
-            <th>message</th>
-            <th>despawn when triggered</th>
-            <th>undetectable</th>
-           </tr>      
-          <tr>
-             <td><input type="text" size="75" name="message" value="<?=$message?>"></td>  
-             <td><select class="left" name="despawn_when_triggered">
-<?foreach($yesno as $k => $v):?>
-              <option value="<?=$k?>"<? echo ($k == $despawn_when_triggered) ? " selected" : ""?>><?=$v?></option>
-<?$x++; endforeach;?>
-           </td> 
-           <td><select class="left" name="undetectable">
-<?foreach($yesno as $k => $v):?>
-              <option value="<?=$k?>"<? echo ($k == $undetectable) ? " selected" : ""?>><?=$v?></option>
-<?$x++; endforeach;?>
-           </td> 
-          </tr>
-           </table><br><br>
-        <center>
-          <input type="hidden" name="tid" value="<?=$id?>">
-          <input type="hidden" name="zone" value="<?=$currzone?>">
-          <input type="submit" value="Submit Changes">
-        </center>
-      </form>
-      </div>
-      </div>
+    <div class="edit_form_header">
+        Edit Trap: <?= $id ?>
+    </div>
+    <div class="edit_form_content">
+        <form name="traps" method="post"
+              action=index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=21">
+            <table style="width: 100%;">
+                <tr>
+                    <th><label for="x_coord">x</label></th>
+                    <th><label for="y_coord">y</label></th>
+                    <th><label for="z_coord">z</label></th>
+                    <th><label for="maxzdiff">maxzdiff</label></th>
+                    <th><label for="radius">radius</label></th>
+                    <th><label for="chance">chance</label></th>
+                    <th><label for="triggered_number">triggered num</label></th>
+                    <th><label for="group">group</label></th>
+                </tr>
+                <tr>
+                    <td><input type="text" size="7" id="x_coord" name="x_coord" value="<?= $x ?? "" ?>"></td>
+                    <td><input type="text" size="7" id="y_coord" name="y_coord" value="<?= $y ?? "" ?>"></td>
+                    <td><input type="text" size="7" id="z_coord" name="z_coord" value="<?= $z ?? "" ?>"></td>
+                    <td><input type="text" size="7" id="maxzdiff" name="maxzdiff" value="<?= $maxzdiff ?? "" ?>"></td>
+                    <td><input type="text" size="7" id="radius" name="radius" value="<?= $radius ?? "" ?>"></td>
+                    <td><input type="text" size="7" id="chance" name="chance" value="<?= $chance ?? "" ?>"></td>
+                    <td><input type="text" size="7" id="triggered_number" name="triggered_number"
+                               value="<?= $triggered_number ?? "" ?>"></td>
+                    <td><input type="text" size="7" id="group" name="group" value="<?= $group ?? "" ?>"></td>
+                </tr>
+                <tr>
+                    <th><label for="effectvalue">effectvalue</label></th>
+                    <th><label for="effectvalue2">effectvalue2</label></th>
+                    <th><label for="skill">skill</label></th>
+                    <th><label for="level">level</label></th>
+                    <th><label for="respawn_time">respawn</label></th>
+                    <th><label for="respawn_var">variance</label></th>
+                    <th><label for="effect">effect</label></th>
+                </tr>
+                <tr>
+                    <td><input type="text" size="7" id="effectvalue" name="effectvalue"
+                               value="<?= $effectvalue ?? "" ?>"></td>
+                    <td><input type="text" size="7" id="effectvalue2" name="effectvalue2"
+                               value="<?= $effectvalue2 ?? "" ?>"></td>
+                    <td><input type="text" size="7" id="skill" name="skill" value="<?= $skill ?? "" ?>"></td>
+                    <td><input type="text" size="7" id="level" name="level" value="<?= $level ?>"></td>
+                    <td><input type="text" size="7" id="respawn_time" name="respawn_time"
+                               value="<?= $respawn_time ?? "" ?>"></td>
+                    <td><input type="text" size="7" id="respawn_var" name="respawn_var"
+                               value="<?= $respawn_var ?? "" ?>"></td>
+                    <td><select class="left" id="effect" name="effect">
+                            <?php foreach ($traptype as $k => $v): ?>
+                                <option value="<?= $k ?>"<?php echo (isset($effect) && $k == $effect) ? " selected" : "" ?>><?= $v ?></option>
+                            <?php endforeach; ?>
+                        </select></td>
+                </tr>
+            </table>
+            <table style="width: 100%;">
+                <tr>
+                    <th><label for="message">message</label></th>
+                    <th><label for="despawn_when_triggered">despawn when triggered</label></th>
+                    <th><label for="undetectable">undetectable</label></th>
+                </tr>
+                <tr>
+                    <td><input type="text" size="75" id="message" name="message" value="<?= $message ?? "" ?>"></td>
+                    <td><select class="left" id="despawn_when_triggered" name="despawn_when_triggered">
+                            <?php foreach ($yesno as $k => $v): ?>
+                                <option value="<?= $k ?>"<?php echo (isset($despawn_when_triggered) && $k == $despawn_when_triggered) ? " selected" : "" ?>><?= $v ?></option>
+                                <?php $x++; endforeach; ?>
+                    </td>
+                    <td><select class="left" id="undetectable" name="undetectable">
+                            <?php foreach ($yesno as $k => $v): ?>
+                                <option value="<?= $k ?>"<?php echo (isset($undetectable) && $k == $undetectable) ? " selected" : "" ?>><?= $v ?></option>
+                                <?php $x++; endforeach; ?>
+                    </td>
+                </tr>
+            </table>
+            <br><br>
+            <div class="center">
+                <input type="hidden" name="tid" value="<?= $id ?>">
+                <input type="hidden" name="zone" value="<?= $currzone ?? "" ?>">
+                <input type="submit" value="Submit Changes">
+            </div>
+        </form>
+    </div>
+</div>

--- a/templates/misc/traps.tmpl.php
+++ b/templates/misc/traps.tmpl.php
@@ -1,75 +1,87 @@
-      <div class="table_container" style="width: 750px;">
-      <div class="table_header">
-        <table width="100%" cellpadding="0" cellspacing="0">
-          <tr>
-           <td>Traps</td>
-           <td align="right">    
-          <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&action=23"><img src="images/add.gif" border="0" title="Add an entry to this zone"></a>
-            </td>
-           </tr>        
-         </table>
-      </div>
-
-       <table class="table_content2" width="100%">
-<? if (isset($traps)):?>
-         <tr>
-          <td align="center" width="5%"><strong>id</strong></td>
-          <td align="center" width="5%"><strong>x</strong></td>
-          <td align="center" width="5%"><strong>y</strong></td>
-          <td align="center" width="5%"><strong>z</strong></td>
-          <td align="center" width="5%"><strong>maxzdiff</strong></td>
-          <td align="center" width="5%"><strong>radius</strong></td>
-          <td align="center" width="5%"><strong>chance</strong></td>
-          <td align="center" width="10%"><strong>effect</strong></td>
-          <td align="center" width="10%"><strong>value</strong></td>
-          <td align="center" width="10%"><strong>value2</strong></td>
-          <td align="center" width="5%"><strong>skill</strong></td>
-          <td align="center" width="5%"><strong>level</strong></td>
-          <td align="center" width="5%"><strong>respawn</strong></td>
-          <td align="center" width="5%"><strong>variance</strong></td>
-          <td align="center" width="5%"><strong>group</strong></td>
-          <th width="5%"></th>
-         </tr>
-<?$x=0; foreach($traps as $traps=>$v):?>
-        <tr bgcolor="#<? echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA";?>">
-          <td align="center" width="5%"><?=$v['tid']?></td>
-          <td align="center" width="5%"><?=$v['x_coord']?></td>
-          <td align="center" width="5%"><?=$v['y_coord']?></td>
-          <td align="center" width="5%"><?=$v['z_coord']?></td>
-          <td align="center" width="5%"><?=$v['maxzdiff']?></td>
-          <td align="center" width="5%"><?=$v['radius']?></td>
-          <td align="center" width="5%"><?=$v['chance']?>%</td>
-          <td align="center" width="10%"><?=$traptype[$v['effect']]?></td>
-<?if($v['effect'] == 2 || $v['effect'] == 3):?>
-          <td align="center" width="10%"><a href="index.php?editor=npc&z=<?=get_zone_by_npcid($v['effectvalue'])?>&zoneid=<?=get_zoneid_by_npcid($v['effectvalue'])?>&npcid=<?=$v['effectvalue']?>"><?=getNPCName($v['effectvalue'])?></td>
-<?endif;?>
-<?if($v['effect'] == 1 || $v['effect'] == 4):?>
-          <td align="center" width="10%"><?=$v['effectvalue']?></td>
-<?endif;?>
-<?if($v['effect'] == 0):?>
-          <td align="center" width="10%"><?=getSpellName($v['effectvalue'])?> <span>[<a href="http://lucy.allakhazam.com/spell.html?id=<?=$v['effectvalue']?>">lucy</a>]</span>
-<?endif;?>    
-<?if($v['effect'] == 1):?>   
-          <td align="center" width="10%"><?=$alarmtype[$v['effectvalue2']]?></td>  
-<?endif;?>
-<?if($v['effect'] < 1 || $v['effect'] > 1):?>
-          <td align="center" width="10%"><?=$v['effectvalue2']?></td>
-<?endif;?> 
-          <td align="center" width="5%"><?=$v['skill']?></td>
-          <td align="center" width="5%"><?=$v['level']?></td>
-          <td align="center" width="5%"><?=$v['respawn_time']?></td>
-          <td align="center" width="5%"><?=$v['respawn_var']?></td>
-          <td align="center" width="5%"><?=$v['group']?></td>
-          <td align="right">      
-            <a href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&tid=<?=$v['tid']?>&action=20"><img src="images/edit2.gif" border="0" title="Edit Entry"></a>          
-            <a onClick="return confirm('Really Delete Trap <?=$v['tid']?>?');" href="index.php?editor=misc&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&tid=<?=$v['tid']?>&action=22"><img src="images/remove3.gif" border="0" title="Delete this entry"></a>
-          </td>
-        </tr>
-        <?$x++; endforeach;?>
+<div class="table_container" style="width: 750px;">
+    <div class="table_header">
+        <table style="width: 100%; border-collapse: collapse; border-spacing: 0;">
+            <tr>
+                <td style="padding: 0;">Traps</td>
+                <td style="padding: 0; text-align: right;">
+                    <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&action=23"><img
+                                src="images/add.gif" style="border: 0;" alt="Add Icon"
+                                title="Add an entry to this zone"></a>
+                </td>
+            </tr>
         </table>
-        <?endif;?>
-<? if (!isset($traps)):?>
-        <tr>
-          <td align="left" width="100" style="padding: 10px;">Walk confidently, there are no traps here</td>
-        </tr>
-<?endif;?>
+    </div>
+
+    <table class="table_content2" style="width: 100%;">
+        <?php if (isset($traps)): ?>
+            <tr>
+                <td style="text-align: center; width: 5%"><strong>id</strong></td>
+                <td style="text-align: center; width: 5%"><strong>x</strong></td>
+                <td style="text-align: center; width: 5%"><strong>y</strong></td>
+                <td style="text-align: center; width: 5%"><strong>z</strong></td>
+                <td style="text-align: center; width: 5%"><strong>maxzdiff</strong></td>
+                <td style="text-align: center; width: 5%"><strong>radius</strong></td>
+                <td style="text-align: center; width: 5%"><strong>chance</strong></td>
+                <td style="text-align: center; width: 10%"><strong>effect</strong></td>
+                <td style="text-align: center; width: 10%"><strong>value</strong></td>
+                <td style="text-align: center; width: 10%"><strong>value2</strong></td>
+                <td style="text-align: center; width: 5%"><strong>skill</strong></td>
+                <td style="text-align: center; width: 5%"><strong>level</strong></td>
+                <td style="text-align: center; width: 5%"><strong>respawn</strong></td>
+                <td style="text-align: center; width: 5%"><strong>variance</strong></td>
+                <td style="text-align: center; width: 5%"><strong>group</strong></td>
+                <th style="width: 5%;"></th>
+            </tr>
+            <?php $x = 0;
+            foreach ($traps as $key => $v): ?>
+                <tr style="background-color: #<?php echo ($x % 2 == 0) ? "BBBBBB" : "AAAAAA"; ?>">
+                    <td style="text-align: center; width: 5%"><?= $v['tid'] ?></td>
+                    <td style="text-align: center; width: 5%"><?= $v['x_coord'] ?></td>
+                    <td style="text-align: center; width: 5%"><?= $v['y_coord'] ?></td>
+                    <td style="text-align: center; width: 5%"><?= $v['z_coord'] ?></td>
+                    <td style="text-align: center; width: 5%"><?= $v['maxzdiff'] ?></td>
+                    <td style="text-align: center; width: 5%"><?= $v['radius'] ?></td>
+                    <td style="text-align: center; width: 5%"><?= $v['chance'] ?>%</td>
+                    <td style="text-align: center; width: 10%"><?= $traptype[$v['effect']] ?></td>
+                    <?php if ($v['effect'] == 2 || $v['effect'] == 3): ?>
+                        <td style="text-align: center; width: 10%"><a
+                                    href="index.php?editor=npc&z=<?= get_zone_by_npcid($v['effectvalue']) ?>&zoneid=<?= get_zoneid_by_npcid($v['effectvalue']) ?>&npcid=<?= $v['effectvalue'] ?>"><?= getNPCName($v['effectvalue']) ?>
+                        </td>
+                    <?php endif; ?>
+                    <?php if ($v['effect'] == 1 || $v['effect'] == 4): ?>
+                        <td style="text-align: center; width: 10%"><?= $v['effectvalue'] ?></td>
+                    <?php endif; ?>
+                    <?php if ($v['effect'] == 0): ?>
+                    <td style="text-align: center; width: 10%"><?= getSpellName($v['effectvalue']) ?> <span>[<a
+                                    href="https://lucy.allakhazam.com/spell.html?id=<?= $v['effectvalue'] ?>">lucy</a>]</span>
+                        <?php endif; ?>
+                        <?php if ($v['effect'] == 1): ?>
+                    <td style="text-align: center; width: 10%"><?= $alarmtype[$v['effectvalue2']] ?></td>
+                <?php endif; ?>
+                    <?php if ($v['effect'] < 1 || $v['effect'] > 1): ?>
+                        <td style="text-align: center; width: 10%"><?= $v['effectvalue2'] ?></td>
+                    <?php endif; ?>
+                    <td style="text-align: center; width: 5%"><?= $v['skill'] ?></td>
+                    <td style="text-align: center; width: 5%"><?= $v['level'] ?></td>
+                    <td style="text-align: center; width: 5%"><?= $v['respawn_time'] ?></td>
+                    <td style="text-align: center; width: 5%"><?= $v['respawn_var'] ?></td>
+                    <td style="text-align: center; width: 5%"><?= $v['group'] ?></td>
+                    <td style="text-align: right;">
+                        <a href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&tid=<?= $v['tid'] ?>&action=20"><img
+                                    src="images/edit2.gif" style="border: 0;" alt="Edit Icon" title="Edit Entry"></a>
+                        <a onClick="return confirm('Really Delete Trap <?= $v['tid'] ?>?');"
+                           href="index.php?editor=misc&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&tid=<?= $v['tid'] ?>&action=22"><img
+                                    src="images/remove3.gif" style="border: 0;" alt="Remove Icon"
+                                    title="Delete this entry"></a>
+                    </td>
+                </tr>
+                <?php $x++; endforeach; ?>
+        <?php endif; ?>
+        <?php if (!isset($traps)): ?>
+            <tr>
+                <td style="text-align: left; width: 100px; padding: 10px;">Walk confidently, there are no traps here
+                </td>
+            </tr>
+        <?php endif; ?>
+    </table>
+</div>

--- a/templates/spellops/spellops.default.tmpl.php
+++ b/templates/spellops/spellops.default.tmpl.php
@@ -6,11 +6,11 @@
          </tr>
          <tr>
            <td class="edit_form_content">
-             <center>
-               <a href="index.php?editor=spellset&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&npcid=<?=$npcid?>">Edit Spell Sets</a><br>
+             <div class="center">
+               <a href="index.php?editor=spellset&z=<?=$currzone ?? ""?>&zoneid=<?=$currzoneid ?? ""?>&npcid=<?=$npcid?>">Edit Spell Sets</a><br>
                <a href="index.php?editor=spells">Edit Spells</a><br>
                <a href="index.php?editor=spells&action=10">Generate spells_en.txt</a>
-             </center>
+             </div>
            </td>
          </tr>
        </table>


### PR DESCRIPTION
… Object) forms

This PR completes syntax and error/warning fixes to all templates in the `misc`, and `spellops` folders.  It also fixes warnings from lib/misc.php and lib/util.php.

UI improvements were made to the Door, Object, and Trap Add/Edit forms.

### Door UI
#### Before:
<img width="796" alt="Screenshot 2024-01-13 at 1 32 00 PM" src="https://github.com/EQMacEmu/takpphpeditor/assets/8131324/e7443331-78d9-48fb-9fce-df989e267386">

#### After:

<img width="796" alt="Screenshot 2024-01-13 at 1 32 18 PM" src="https://github.com/EQMacEmu/takpphpeditor/assets/8131324/628e73ee-5bee-464f-83b1-287e403f680f">


