### PR TITLE
UI improvements to item editor template

### DIFF
--- a/css/peq.css
+++ b/css/peq.css
@@ -270,3 +270,28 @@ table {
 .alert-success {
     color: #00FF00;
 }
+/* Tooltip container */
+.tooltip {
+    position: relative;
+    display: inline-block;
+    border-bottom: 1px dotted black; /* If you want dots under the hoverable text */
+}
+
+/* Tooltip text */
+.tooltip .tooltiptext {
+    visibility: hidden;
+    width: 120px;
+    background-color: black;
+    color: #fff;
+    text-align: left;
+    padding: 5px 0 5px 10px;
+    border-radius: 6px;
+
+    position: absolute;
+    z-index: 1;
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.tooltip:hover .tooltiptext {
+    visibility: visible;
+}

--- a/templates/items/items.edit.tmpl.php
+++ b/templates/items/items.edit.tmpl.php
@@ -61,9 +61,9 @@
                         <span class="tooltiptext">0: Non-Stackable<br />1: Stackable<br />2: Unused<br />3: Spell Effect<br /></span>
                     </div><br/>
                     <select id="stackable" name="stackable">
-                        <option value="0"<?php echo (isset($stackable) && $stackable == 0) ? "selected" : ""?>>Non-Stackable</option>
-                        <option value="1"<?php echo (isset($stackable) && $stackable == 1) ? "selected" : ""?>>Stackable</option>
-                        <option value="3"<?php echo (isset($stackable) && $stackable == 3) ? "selected" : ""?>>Spell Effect</option>
+                        <option value="0"<?php echo (isset($stackable) && $stackable == 0) ? " selected" : ""?>>0: Non-Stackable</option>
+                        <option value="1"<?php echo (isset($stackable) && $stackable == 1) ? " selected" : ""?>>1: Stackable</option>
+                        <option value="3"<?php echo (isset($stackable) && $stackable == 3) ? " selected" : ""?>>3: Spell Effect</option>
                     </select>
                 </td>
                 <td style="padding: 3px; text-align: left; width: 33%;"><label for="stacksize">Stacksize:</label><br/><input type="text" id="stacksize" name="stacksize" size="10" value="<?=$stacksize ?? ""?>"></td>

--- a/templates/items/items.edit.tmpl.php
+++ b/templates/items/items.edit.tmpl.php
@@ -55,7 +55,17 @@
           </table>
           <table style="width: 100%; border-collapse: collapse: border-spacing: 0;">
             <tr>
-                <td style="padding: 3px; text-align: left; width: 34%;"><label for="stackable">Stackable:</label><br/><input type="text" id="stackable" name="stackable" size="10" value="<?=$stackable ?? ""?>"></td>
+                <td style="padding: 3px; text-align: left; width: 34%;">
+                    <label for="stackable">Stackable:</label>
+                    <div class="tooltip">(?)
+                        <span class="tooltiptext">0: Non-Stackable<br />1: Stackable<br />2: Unused<br />3: Spell Effect<br /></span>
+                    </div><br/>
+                    <select id="stackable" name="stackable">
+                        <option value="0"<?php echo (isset($stackable) && $stackable == 0) ? "selected" : ""?>>Non-Stackable</option>
+                        <option value="1"<?php echo (isset($stackable) && $stackable == 1) ? "selected" : ""?>>Stackable</option>
+                        <option value="3"<?php echo (isset($stackable) && $stackable == 3) ? "selected" : ""?>>Spell Effect</option>
+                    </select>
+                </td>
                 <td style="padding: 3px; text-align: left; width: 33%;"><label for="stacksize">Stacksize:</label><br/><input type="text" id="stacksize" name="stacksize" size="10" value="<?=$stacksize ?? ""?>"></td>
                 <td style="padding: 3px; text-align: left; width: 33%;"><label for="maxcharges">Charges:</label><br/><input type="text" id="maxcharges" name="maxcharges" size="10" value="<?=$maxcharges ?? ""?>"></td>
             </tr>
@@ -488,7 +498,12 @@
                       <?php endforeach;?>
                   </select>
                 </td>
-                  <td style="padding: 3px; text-align: left; width: 16%"><label for="worneffect">Worn Effect:</label><br/><input type="text" id="worneffect" name="worneffect" size="5" value="<?=$worneffect ?? ""?>"></td>
+                  <td style="padding: 3px; text-align: left; width: 16%">
+                      <label for="worneffect">Worn Effect:</label>
+                      <div class="tooltip">(?)
+                          <span class="tooltiptext">Set Stackable to 3</span>
+                      </div><br/>
+                      <input type="text" id="worneffect" name="worneffect" size="5" value="<?=$worneffect ?? ""?>"></td>
                   <td style="padding: 3px; text-align: left; width: 16%"><label for="wornlevel">Worn Level:</label><br/><input type="text" id="wornlevel" name="wornlevel" size="5" value="<?=$wornlevel ?? ""?>"></td>
                   <td style="padding: 3px; text-align: left; width: 16%"><label for="wornlevel2">Worn Level 2:</label><br/><input type="text" id="wornlevel2" name="wornlevel2" size="5" value="<?=$wornlevel2 ?? ""?>"></td>
                 <td style="padding: 3px; text-align: left; width: 16%">&nbsp;</td>


### PR DESCRIPTION
Adds a tooltip class to the css so helpful hints can be placed in the templates.  Changes the stackable field to a dropdown since there are only 3 correct options, and this allows for helpful context indicating the meaning of these values.