### PR TITLE
Spellsets/spellset add

### DIFF
--- a/templates/spellset/spellset.add.tmpl.php
+++ b/templates/spellset/spellset.add.tmpl.php
@@ -11,8 +11,8 @@
     <div class="edit_form_content">
         <form method="post"
               action="index.php?editor=spellset&z=<?= $currzone ?? "" ?>&zoneid=<?= $currzoneid ?? "" ?>&npcid=<?= $npcid ?>&action=11">
-            <strong><label for="id">Suggested ID:</label></strong><br>
-            <input class="indented" type="text" id="id" name="id" size="10" value="<?= $id ?>"><br><br>
+            <strong><label for="suggested_id">Suggested ID:</label></strong><br>
+            <input class="indented" type="text" id="suggested_id" name="id" size="10" value="<?= $id ?>"><br><br>
 
             <strong><label for="name">Spellset Name:</label></strong><br>
             <input class="indented" type="text" id="name" name="name" size="25" value="<?= $name ?? "" ?>"><br><br>


### PR DESCRIPTION
Fixes issue where searching for and selecting a spell from spell search while creating a new spellset was putting the spell id in the suggested ids field instead of the attack proc field.