### PR TITLE
Fix adding items to merchants

### DIFF
--- a/lib/merchant.php
+++ b/lib/merchant.php
@@ -51,6 +51,10 @@ switch ($action) {
     $body->set('currzoneid', $zoneid);
     $body->set('npcid', $npcid);
     $body->set('mid', $_GET['mid']);
+    $slot = next_slot($_GET['mid']);
+    if ($slot) {
+        $body->set('slot', $slot);
+    }
     break;
   case 5: // Add item
     check_authorization();
@@ -343,7 +347,7 @@ function add_merchant_item(): void
     $classes_value = $classes_value ^ $v;
   }
  
- $query = "INSERT INTO merchantlist SET merchantid=$mid, slot=$slot, item=$item, faction_required=$faction_required, level_required=$level_required, classes_required=$classes_value, quantity=$quantity, min_expansion=$min_expansion, max_expansion=$max_expansion, content_flags=NULL, content_flags_disabled=NULL";
+  $query = "INSERT INTO merchantlist SET merchantid=$mid, slot=$slot, item=$item, faction_required=$faction_required, level_required=$level_required, classes_required=$classes_value, quantity=$quantity, min_expansion=$min_expansion, max_expansion=$max_expansion, content_flags=NULL, content_flags_disabled=NULL";
   $mysql->query_no_result($query);
   
   if ($content_flags != "") {
@@ -384,6 +388,14 @@ function add_merchant_item_temp(): void
     $query = "INSERT INTO merchantlist_temp SET npcid=$npcid, slot=$tslot, itemid=$itemid, charges=$charges, quantity=1";
     $mysql->query_no_result($query);
   }
+}
+
+function next_slot($merchantid) {
+    global $mysql;
+    $query = "SELECT MAX(slot) AS slot FROM merchantlist WHERE merchantid=$merchantid";
+    $result = $mysql->query_assoc($query);
+
+    return $result['slot'] + 1;
 }
 
 function delete_merchantlist(): void

--- a/templates/merchant/item.add.tmpl.php
+++ b/templates/merchant/item.add.tmpl.php
@@ -6,7 +6,7 @@
   </div>
   <div>
     <form method="post" name="merchant_item" action="index.php?editor=merchant&z=<?=$currzone?>&zoneid=<?=$currzoneid?>&npcid=<?=$npcid?>&action=5">
-      <div class="edit_form" style="width: 550px">
+      <div class="edit_form" style="width: 650px">
         <div class="edit_form_header">Add an Item to Merchant</div>
         <div class="edit_form_content">
           <table width="100%" cellpadding="3" cellspacing="3">


### PR DESCRIPTION
Fixes an issue where the next available slot in merchantlist wasn't being passed to the add item template for merchants.  As a result, trying to submit a new item was failing with a 500 error due to the slot field being blank in the SQL query.

This solution mirrors the solution that was implemented in the peqphpeditor.