### PR TITLE
Fixes minor bug with too many types in query

### DIFF
--- a/lib/loot.php
+++ b/lib/loot.php
@@ -889,7 +889,7 @@ function update_lootdrop_item(): void
         SET equip_item = ?, item_charges = ?, chance = ?, minlevel = ?, maxlevel = ?, multiplier = ?, min_expansion = ?, max_expansion = ?, content_flags = NULL, content_flags_disabled = NULL
         WHERE lootdrop_id = ? AND item_id = ?",
         [$equip, $charges, $chance, $minlevel, $maxlevel, $multiplier, $min_expansion, $max_expansion, $ldid, $itemid],
-        'iidiiiiiiii'
+        'iidiiiiiii'
     );
 
     if ($content_flags != "") {


### PR DESCRIPTION
This fixes a minor typo where I added one too many `i` integer types to a parameterized query